### PR TITLE
Fix bug in 1kuns image decoder

### DIFF
--- a/python/sat_1kuns_pf_image_decoder.py
+++ b/python/sat_1kuns_pf_image_decoder.py
@@ -81,13 +81,11 @@ class sat_1kuns_pf_image_decoder(gr.basic_block):
         elif block != self.expected_block:
             # lost block
             print "Lost image block {}".format(self.expected_block)
-            self.expected_block = block + 1
-            return
         else:
             print "Received image block {}".format(block)
 
         self.f.write(data)
-        self.expected_block += 1
+        self.expected_block = block + 1
 
         if self.display and not self.displaying and block >= 5:
             self.displaying = True

--- a/python/sat_1kuns_pf_image_decoder.py
+++ b/python/sat_1kuns_pf_image_decoder.py
@@ -81,9 +81,8 @@ class sat_1kuns_pf_image_decoder(gr.basic_block):
         elif block != self.expected_block:
             # lost block
             print "Lost image block {}".format(self.expected_block)
-        else:
-            print "Received image block {}".format(block)
-
+        
+        print "Received image block {}".format(block)
         self.f.write(data)
         self.expected_block = block + 1
 


### PR DESCRIPTION
Hi, I notice that if we lose an image block, we don't write out the block that we *actually* received and instead return early. I'm assuming that isn't the intended behavior?