### PR TITLE
Maint 3.8 fixes

### DIFF
--- a/grc/satellites_matrix_deinterleaver_soft.block.yml
+++ b/grc/satellites_matrix_deinterleaver_soft.block.yml
@@ -4,19 +4,19 @@ category: '[Satellites]/Coding'
 
 parameters:
 -   id: rows
-    labels: Rows
+    label: Rows
     dtype: int
     default: '80'
 -   id: cols
-    labels: Columns
+    label: Columns
     dtype: int
     default: '65'
 -   id: output_size
-    labels: Output size
+    label: Output size
     dtype: int
     default: '5132'
 -   id: output_skip
-    labels: Output skip
+    label: Output skip
     dtype: int
     default: '65'
 

--- a/grc/satellites_smogp_packet_filter.block.yml
+++ b/grc/satellites_smogp_packet_filter.block.yml
@@ -2,8 +2,6 @@ id: satellites_smogp_packet_filter
 label: SMOG-P/ATL-1 packet filter
 category: '[Satellites]/Telemetry'
 
-parameters:
-
 inputs:
 -   domain: message
     id: in


### PR DESCRIPTION
I found some warnings trying to use gr-satellites. It is some minor typos in the block.yml files. Please consider to merge this. If you don't like the long lines int he commit message for the statement of the warning the patches fix, I can remove them if you like.

Tested locally by seeing that I don't see the warnings anymore when starting grc.