### PR TITLE
Do not use Embedded() function from construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3] - 2020-02-05
+- Support for construct 2.10 (followed master branch 2dcf92beb727542a9153da923735c1614653b177)
+
 ## [1.8.2] - 2019-11-01
 ### Fixed
 - Corrected FACSAT NORAD ID

--- a/python/funcube_telemetry.py
+++ b/python/funcube_telemetry.py
@@ -321,14 +321,10 @@ WholeOrbitFC1 = BitStruct(
 
 Callsign = Bytes(8)
 
-FC2BatteryCommon = Struct(
-    'current' / Octet,
-    'voltage' / Octet,
-    )
-
 FC2Battery = Struct(
     'direction' / Flag,
-    Embedded(FC2BatteryCommon),
+    'current' / Octet,
+    'voltage' / Octet,
     'temp' / Octet,
     )
 
@@ -372,13 +368,15 @@ RealTimeFC2 = BitStruct(
     )
 
 FC2Battery0 = Struct(
-    Embedded(FC2BatteryCommon),
+    'current' / Octet,
+    'voltage' / Octet,
     'temp' / Octet,
     )
 
 FC2Battery2 = Struct(
     'direction' / Flag,
-    Embedded(FC2BatteryCommon),
+    'current' / Octet,
+    'voltage' / Octet,
     )
 
 WholeOrbitFC2 = BitStruct(

--- a/python/picsat_telemetry.py
+++ b/python/picsat_telemetry.py
@@ -133,7 +133,7 @@ BeaconD = Struct(
     'sat_mode' / Int8ub,
     'tc_sequence_count' / Int16ub)
 
-Beacon = Struct(Padding(3), BeaconA, Embedded(BeaconB), BeaconC, Embedded(BeaconD))
+Beacon = Struct(Padding(3), BeaconA, BeaconB, BeaconC, BeaconD)
 
 PayloadBeaconFlags = BitStruct(
     'hk_flag' / Flag,


### PR DESCRIPTION
>This has been removed from construct v2.10

It followed master branch 2dcf92beb727542a9153da923735c1614653b177
It resolved harmless warning message.

>NameError("name 'Embedded' is not defined",)