### PR TITLE
Added support for VZLUSAT-2

### DIFF
--- a/python/satyaml/VZLUSAT-2.yml
+++ b/python/satyaml/VZLUSAT-2.yml
@@ -1,0 +1,20 @@
+name: VZLUSAT-2
+norad: 12345
+data:
+  &tlm Telemetry:
+    telemetry: vzlusat_2
+transmitters:
+  9k6 FSK downlink:
+    frequency: 437.325e+6
+    modulation: FSK
+    baudrate: 9600
+    framing: AX100 ASM+Golay
+    data:
+    - *tlm
+  4k8 FSK downlink:
+    frequency: 437.325e+6
+    modulation: FSK
+    baudrate: 4800
+    framing: AX100 ASM+Golay
+    data:
+    - *tlm

--- a/python/satyaml/VZLUSAT-2.yml
+++ b/python/satyaml/VZLUSAT-2.yml
@@ -1,5 +1,5 @@
 name: VZLUSAT-2
-norad: 12345
+norad: 99997
 data:
   &tlm Telemetry:
     telemetry: vzlusat_2

--- a/python/telemetry/CMakeLists.txt
+++ b/python/telemetry/CMakeLists.txt
@@ -59,6 +59,7 @@ GR_PYTHON_INSTALL(
     suomi100.py
     trisat.py
     upmsat_2.py
+    vzlusat_2.py
     DESTINATION ${GR_PYTHON_DIR}/satellites/telemetry
 )
 

--- a/python/telemetry/__init__.py
+++ b/python/telemetry/__init__.py
@@ -49,3 +49,4 @@ from .suomi100 import suomi100
 from .by70_1 import taurus1
 from .trisat import trisat
 from .upmsat_2 import upmsat_2
+from .vzlusat_2 import vzlusat_2

--- a/python/telemetry/vzlusat_2.py
+++ b/python/telemetry/vzlusat_2.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 jgromes <gromes.jan@gmail.com>
+#
+# This file is part of gr-satellites
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from construct import *
+from ..adapters import *
+from .csp import CSPHeader
+
+Beacon = Struct(
+    Padding(8),
+    'obc_timestamp' / Int32ub,
+    'obc_boot_count' / Int32ub,
+    'obc_reset_cause' / Int32ub,
+    'eps_vbatt' / Int16ub,
+    'eps_cursun' / Int16ub,
+    'eps_cursys' / Int16ub,
+    'eps_temp_bat' / Int16sb,
+    'radio_temp_pa' / LinearAdapter(10, Int16sb),
+    'radio_tot_tx_count' / Int32ub,
+    'radio_tot_rx_count' / Int32ub
+    )
+
+Drop = Struct(
+    'flag' / Int8ub,
+    'chunk' / Int32ub,
+    'time' / Int32ub,
+    'data' / HexDump(GreedyBytes),
+    )
+
+vzlusat_2 = Struct(
+    'csp_header' / CSPHeader,
+    'cmd' / Hex(Int8ub),
+    'payload' / IfThenElse((this.csp_header.source == 1) & (this.csp_header.destination == 26) & (this.csp_header.source_port == 18) & (this.csp_header.destination_port == 18),
+                Switch(this.cmd, {
+                    0x56 : Beacon,
+                    0x03 : Drop
+                    }, default = HexDump(GreedyBytes)),
+                HexDump(GreedyBytes)
+            )
+    )


### PR DESCRIPTION
Hi,

as mentioned in #167, I added support for VZLUSAT-2, which is an upcoming 3U cubesat by Czech Aerospace Research Center, scheduled for launch with SpaceX on 18th December. The mission goal is an in-orbit technology demonstration of experimental space weather and radiation monitoring equipment, and experimental EO camera.

VZLUSAT-2 has a 9k6/4k8 FSK downlink and beacon with AX100 framing (ASM mode), IARU coordination can be found here: http://www.amsatuk.me.uk/iaru/finished_detail.php?serialnum=749. Telemetry parser includes definitions for beacon frames and data drop packets. One thing to note is that at this point we don't have a NORAD ID, so the one in the YAML file (12345) is just a placeholder. I can also provide audio recording sample if you're intersted.

Let me know if there's something that should be changed.