### PR TITLE
cmake, docs: Add ENABLE_MANPAGES option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,15 @@ else(DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 ########################################################################
+# Setup manpage option
+########################################################################
+if(NOT WIN32)
+    option(ENABLE_MANPAGES "Build man pages for commands" ON)
+else(NOT WIN32)
+    option(ENABLE_MANPAGES "Build man pages for commands" OFF)
+endif(NOT WIN32)
+
+########################################################################
 # Create uninstall target
 ########################################################################
 configure_file(

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,6 +39,8 @@ endif(ENABLE_DOXYGEN)
 ########################################################################
 # Man pages
 ########################################################################
+if(ENABLE_MANPAGES)
+
 FIND_PROGRAM(BZIP
              NAMES bzip2
              PATHS /bin
@@ -70,3 +72,5 @@ foreach(manpage ${manpages})
        DESTINATION ${MAN_INSTALL_DIR}/man1
     )
 endforeach(manpage)
+
+endif(ENABLE_MANPAGES)


### PR DESCRIPTION
Add a CMAKE flag for enabling/disabling manpage generation. This defaults to OFF for Windows and ON for every other platform. Native Windows installations won't usually have a `man` reader, nor will they necessarily have `bzip2` for compressing the man pages. By having the option and defaulting to OFF on Windows, it's easier to build gr-satellites by default (e.g. for conda).