### PR TITLE
Update AISTECHSAT-2.yml

### DIFF
--- a/python/satyaml/AISTECHSAT-2.yml
+++ b/python/satyaml/AISTECHSAT-2.yml
@@ -2,9 +2,16 @@ name: AISTECHSAT-2
 norad: 43768
 data:
   &tlm Telemetry:
-    telemetry: lume
+    unknown
 transmitters:
-  4k8 FSK downlink:
+  1k2 FSK downlink:
+    frequency: 436.600e+6
+    modulation: FSK
+    baudrate: 1200
+    framing: AX100 ASM+Golay
+    data:
+    - *tlm
+4k8 FSK downlink:
     frequency: 436.600e+6
     modulation: FSK
     baudrate: 4800

--- a/python/satyaml/AISTECHSAT-2.yml
+++ b/python/satyaml/AISTECHSAT-2.yml
@@ -11,7 +11,7 @@ transmitters:
     framing: AX100 ASM+Golay
     data:
     - *tlm
-4k8 FSK downlink:
+  4k8 FSK downlink:
     frequency: 436.600e+6
     modulation: FSK
     baudrate: 4800


### PR DESCRIPTION
I changed the telemetry option to unknown and added the 1200 baud transmitter, currently the system seems to operating in 1k2 mode.
With this yaml file it is possible to decode the following SatNOGS observation: https://network.satnogs.org/observations/3108283/
There is no readable ASCII in the output so it is still difficult to determine with certainty that this is AISTECHSAT-2.