### PR TITLE
Update MEZNSAT.yml with 2k4 support

### DIFF
--- a/python/satyaml/MEZNSAT.yml
+++ b/python/satyaml/MEZNSAT.yml
@@ -11,7 +11,14 @@ transmitters:
     framing: AX.25 G3RUH
     data:
     - *tlm
-  9k6 BPSK downlink:
+  2k4 BPSK downlink:
+    frequency: 436.600e+6
+    modulation: BPSK
+    baudrate: 2400
+    framing: AX.25 G3RUH
+    data:
+    - *tlm
+9k6 BPSK downlink:
     frequency: 436.600e+6
     modulation: BPSK
     baudrate: 9600

--- a/python/satyaml/MEZNSAT.yml
+++ b/python/satyaml/MEZNSAT.yml
@@ -18,7 +18,7 @@ transmitters:
     framing: AX.25 G3RUH
     data:
     - *tlm
-9k6 BPSK downlink:
+  9k6 BPSK downlink:
     frequency: 436.600e+6
     modulation: BPSK
     baudrate: 9600


### PR DESCRIPTION
Based on the following observation `https://network.satnogs.org/observations/3225763/` adding 2k4 BPSK to MEZNSAT.

`gr_satellites MEZNSAT --wav MEZNSAT_satnogs_3225763_2020-11-30T23-50-12.wav --samp_rate 48e3 --f_offset 12e3 --hexdump`

```

* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 2k4 BPSK downlink))
pdu_length = 94
contents = 
0000: 82 6c 70 9a 92 40 e0 82 6c 70 9a b4 40 61 03 f0 
0010: 4d 45 5a 4e 53 41 54 01 1e 02 17 33 36 66 00 00 
0020: 00 08 00 c7 3f 96 00 05 00 fd ff fc ff 32 00 56 
0030: 02 43 00 e0 09 00 00 01 ff ff f8 ff 02 00 00 00 
0040: fa ff 00 00 c1 02 a6 c3 ff ff 22 bc ff ff 0c bd 
0050: ff ff 29 d3 ff ff 92 c6 ff ff fc a7 ff ff 
***********************************
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 2k4 BPSK downlink))
pdu_length = 94
contents = 
0000: 82 6c 70 9a 92 40 e0 82 6c 70 9a b4 40 61 03 f0 
0010: 4d 45 5a 4e 53 41 54 01 1e 02 17 34 36 66 00 00 
0020: 00 08 00 b3 3f 96 00 04 00 fc ff fc ff 32 00 5b 
0030: 02 44 00 ec 09 01 00 01 01 00 0e 00 fe ff 00 00 
0040: f6 ff 00 00 c2 02 a4 c1 ff ff b4 b8 ff ff 21 ba 
0050: ff ff d4 cf ff ff 25 c2 ff ff 89 a8 ff ff
```