### PR TITLE
Fix swapped RS basis options in CCSDS Reed-Solomon encoder GRC block too.

### DIFF
--- a/grc/satellites_encode_rs_ccsds.block.yml
+++ b/grc/satellites_encode_rs_ccsds.block.yml
@@ -6,7 +6,7 @@ parameters:
 -   id: basis
     label: Basis
     dtype: enum
-    options: ['True', 'False']
+    options: ['False', 'True']
     option_labels: [Conventional, Dual]
 -   id: interleave
     label: Interleave depth


### PR DESCRIPTION
See 5484a1bdf79acf04242b59a5eb79e794bf7ccd74.