### PR TITLE
Update CubeSX-Sirius-HSE.yml

### DIFF
--- a/python/satyaml/CubeSX-Sirius-HSE.yml
+++ b/python/satyaml/CubeSX-Sirius-HSE.yml
@@ -4,6 +4,13 @@ data:
   &tlm Telemetry:
     telemetry: ax25
 transmitters:
+  4k8 FSK downlink:
+    frequency: 437.050e+6
+    modulation: FSK
+    baudrate: 4800
+    framing: USP
+    data:
+    - *tlm
   9k6 FSK downlink:
     frequency: 437.050e+6
     modulation: FSK


### PR DESCRIPTION
Added the 4k8 baud rate, the satellites is switched to 4k8 as can be seen in this SatNOGS observation https://network.satnogs.org/observations/3835689/