### PR TITLE
Update S-NET_A.yml

### DIFF
--- a/python/satyaml/S-NET_A.yml
+++ b/python/satyaml/S-NET_A.yml
@@ -1,5 +1,5 @@
 name: S-NET A
-norad: 43186
+norad: 43188
 alternative_names:
   - DP0TBB
 data:


### PR DESCRIPTION
Based on the information that can be found on https://www.raumfahrttechnik.tu-berlin.de/menue/amateur_radio/
I propose to alter the norad ID

```
S-Net A 43188 435.950 AFSK 1200 DP0TBB
S-Net B 43187 435.950 AFSK 1200 DP0TBC
S-Net C 43189 435.950 AFSK 1200 DP0TBD
S-Net D 43186 435.950 AFSK 1200 DP0TBE
```