### PR TITLE
Update OrbiCraft-Zorkiy.yml

### DIFF
--- a/python/satyaml/OrbiCraft-Zorkiy.yml
+++ b/python/satyaml/OrbiCraft-Zorkiy.yml
@@ -4,6 +4,20 @@ data:
   &tlm Telemetry:
     telemetry: ax25
 transmitters:
+  1k2 FSK downlink:
+    frequency: 437.850e+6
+    modulation: FSK
+    baudrate: 1200
+    framing: USP
+    data:
+    - *tlm
+  4k8 FSK downlink:
+    frequency: 437.850e+6
+    modulation: FSK
+    baudrate: 4800
+    framing: USP
+    data:
+    - *tlm
   9k6 FSK downlink:
     frequency: 437.850e+6
     modulation: FSK


### PR DESCRIPTION
OrbiCraft-Zorkiy is currently active in a lower baud rate and there added other 1k2 and 4k8 to the satyaml file.

`gr_satellites 47960 --wavfile 47960_satnogs_3937847_2021-04-13T06-25-02.wav --samp_rate 48e3 --hexdump`

```
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 4k8 FSK downlink) (rs_errors . 5) (iterations . -1))
pdu_length = 90
contents = 
0000: a4 64 82 9c 8c 40 60 a4 a6 62 6a a6 40 6d 00 f0 
0010: 16 42 02 00 01 00 42 00 7e 00 56 00 7b 00 21 00 
0020: 20 00 1f 00 3a fe 00 00 00 00 00 00 00 00 03 00 
0030: 02 00 4e 00 4e 00 00 00 00 00 8d 1e da 7b 00 00 
0040: 19 3a 75 60 c8 04 10 0c ff 74 22 14 11 1e 19 3a 
0050: 75 60 08 7f 00 00 fe 00 90 1e 
***********************************
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 4k8 FSK downlink) (rs_errors . 0) (iterations . -1))
pdu_length = 139
contents = 
0000: a4 64 82 9c 8c 40 60 a4 a6 62 6a a6 40 6d 00 f0 
0010: 04 f2 05 00 01 00 73 00 b8 16 13 c2 d4 bf 05 00 
0020: 9b 29 d3 be 6d 1a 34 3d 03 32 ab be 0b a5 58 3f 
0030: 4b 49 71 c0 3e 06 41 3e 07 27 1e 3f 83 b8 16 13 
0040: c2 d4 bf 05 00 82 be ce 3e 29 d0 f2 bb 60 8d 0d 
0050: bf c0 92 3a 3f 83 fd 2a 3f dc 9f 10 40 12 d5 40 
0060: 40 83 b8 16 13 c2 d4 bf 05 00 00 00 80 3f 00 00 
0070: 00 00 00 00 00 00 00 00 00 00 4b 49 71 c0 3e 06 
0080: 41 3e 07 27 1e 3f 86 ff ff f0 fc 
***********************************
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 4k8 FSK downlink) (rs_errors . 0) (iterations . -1))
pdu_length = 90
contents = 
0000: a4 64 82 9c 8c 40 60 a4 a6 62 6a a6 40 6d 00 f0 
0010: 16 42 02 00 01 00 42 00 7b 00 54 00 79 00 20 00 
0020: 1f 00 1e 00 3a fe 00 00 00 00 00 00 00 00 03 00 
0030: 01 00 4e 00 4e 00 00 00 00 00 88 1e 34 7c 00 00 
0040: 73 3a 75 60 c8 04 10 0c ff 74 23 14 11 1e 73 3a 
0050: 75 60 62 7f 00 00 ff 00 8c 1e
```