### PR TITLE
Typo in doc / import satellites.filereceiver

### DIFF
--- a/docs/source/components.rst
+++ b/docs/source/components.rst
@@ -645,7 +645,7 @@ display image files in realtime using `feh`_ as they are being received.
 These receiver blocks use *FileReceiver definitions*, which are
 classes derived from ``FileReceiver``. The list of available definitions can be
 seen in ``python/filereceiver/__index__.py``, or by calling
-``import satellites.filreceiver; help(satellites.filereceiver)`` in
+``import satellites.filereceiver; help(satellites.filereceiver)`` in
 ``python3``. Classes used by the Image receiver must be derived from ``ImageReceiver``.
 
 The figure below shows an example flowgraph of the Image receiver block, which can be


### PR DESCRIPTION
Typo on syntax for using python command to show available image classes.  For anyone (like myself) who relies on copy/paste to benefit from your commands, of course one missing "e" causes this command to fail.  Thanks!