### PR TITLE
Update BEESAT-1.yml

### DIFF
--- a/python/satyaml/BEESAT-1.yml
+++ b/python/satyaml/BEESAT-1.yml
@@ -11,3 +11,10 @@ transmitters:
     framing: Mobitex-NX
     data:
     - *tlm
+  9k6 FSK downlink:
+    frequency: 435.950e+6
+    modulation: FSK
+    baudrate: 9600
+    framing: Mobitex-NX
+    data:
+    - *tlm


### PR DESCRIPTION
Based on the audio files provided by the BEESAT team it is also using the 9k6 baudrate and therefor add this option to the yml file.

I have tested the following cli options `gr_satellites BEESAT-1 --wavfile b1-fm-2021-09-20-180600utc.wav --samp_rate 48e3 --clk_bw 0.3`

