### PR TITLE
Create D-STAR_ONE_LightSat.yml

### DIFF
--- a/python/satyaml/D-STAR_ONE_LightSat.yml
+++ b/python/satyaml/D-STAR_ONE_LightSat.yml
@@ -1,0 +1,13 @@
+name: D-STAR ONE LightSat
+norad: 44393
+data:
+  &tlm Telemetry:
+    telemetry: dstar_one
+transmitters:
+  4k8 FSK downlink:
+    frequency: 435.700e+6
+    modulation: FSK
+    baudrate: 4800
+    framing: Mobitex
+    data:
+    - *tlm


### PR DESCRIPTION
Based on the following observation https://network.satnogs.org/observations/5513595/ we seem to have confirmation in D-STAR One Lightsat

```
-> Packet from 4k8 FSK downlink
Container: 
    control = b'\x0b\x06' (total 2)
    beacon = Container: 
        time = 1645539496
        reboots = 369
        rtc_val = 1645539489
        bat_charge_in = 0.3436279296875
        bat_charge_out = 0.08138020833333333
        bat_voltage = 8.296415231523724
        supply_5V = 5.141179011418269
        supply_3V3 = 3.304443359375
        pcu_total_curr = 0.0545654296875
        solar_curr = ListContainer: 
            0.61676025390625
            0.003662109375
            0.0848388671875
            0.0030517578125
            0.03326416015625
            0.0018310546875
        solar_total_v = 3.1196946364182696
        vcc_curr = ListContainer: 
            0.0018310546875
            0.0018310546875
            0.00091552734375
            0.0030517578125
        vcc_curr2 = ListContainer: 
            0.01220703125
            0.010986328125
            0.0006103515625
            0.008544921875
        ss_total_curr = 0.0048828125
        eeprom_curr1 = 0.00091552734375
        eeprom_curr2 = 9.1552734375e-05
        ext_adc_curr = ListContainer: 
            0.0001220703125
            6.103515625e-05
            9.1552734375e-05
            0.0
        rtc_curr = 0.00018310546875
        charger_dcdc_v = 0.55572509765625
        system_v = 0.8074951171875
        obc_curr = 0.00274658203125
        switches = ListContainer: 
            192
            210
            3
        reserved1 = 0
        battery_temp = 28673
        schedule = 0
        reserved2 = b'\x00\ng\x00\x00\x00\\\x02\x01\x10' (total 10)
        mode = 2
        filler = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff' (total 10)
        crc = 64894
```