### PR TITLE
Update Eaglet-I.yml

### DIFF
--- a/python/satyaml/Eaglet-I.yml
+++ b/python/satyaml/Eaglet-I.yml
@@ -3,11 +3,20 @@ norad: 43790
 data:
   &tlm Telemetry:
     telemetry: ax25
+  &tlm1 unknown:
+    unknown
 transmitters:
+  1k2 BPSK downlink:
+    frequency: 435.200e+6
+    modulation: BPSK
+    baudrate: 1200
+    framing: AX.25 G3RUH
+    data:
+    - *tlm
   9k6 FSK downlink:
     frequency: 435.800e+6
     modulation: FSK
     baudrate: 9600
     framing: AX.25 G3RUH
     data:
-    - *tlm
+    - *tlm1


### PR DESCRIPTION
This satellite seam to have two transmitter https://db.satnogs.org/satellite/NMSF-0466-6077-1186-9611#transmitters
Therefor I added the BPSK options to the yml file. When the FSK definition is indeed AIS then maybe the framing needs to change.