### PR TITLE
Fix bug in kiss_server_sink

### DIFF
--- a/python/components/datasinks/CMakeLists.txt
+++ b/python/components/datasinks/CMakeLists.txt
@@ -49,4 +49,5 @@ include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-satellites)
 set(GR_TEST_PYTHON_DIRS ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/swig)
+GR_ADD_TEST(qa_kiss_server_sink ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_kiss_server_sink.py)
 GR_ADD_TEST(qa_telemetry_parser ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_telemetry_parser.py)

--- a/python/components/datasinks/kiss_server_sink.py
+++ b/python/components/datasinks/kiss_server_sink.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2020 Daniel Estevez <daniel@destevez.net>
+# Copyright 2020, 2022 Daniel Estevez <daniel@destevez.net>
 #
 # This file is part of gr-satellites
 #
@@ -35,6 +35,8 @@ class kiss_server_sink(gr.hier_block2):
         self.message_port_register_hier_in('in')
 
         self.kiss = pdu_to_kiss(include_timestamp=True)
+        # port needs to be an str
+        port = str(port)
         self.server = blocks.socket_pdu(
             'TCP_SERVER', address, port, 10000, False)
 

--- a/python/components/datasinks/qa_kiss_server_sink.py
+++ b/python/components/datasinks/qa_kiss_server_sink.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2020, 2022 Daniel Estevez <daniel@destevez.net>
+#
+# This file is part of gr-satellites
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+
+from gnuradio import gr, blocks, gr_unittest
+import numpy as np
+import pmt
+
+
+# bootstrap satellites module, even from build dir
+try:
+    import python as satellites
+except ImportError:
+    pass
+else:
+    import sys
+    sys.modules['satellites'] = satellites
+
+from satellites.components.datasinks import kiss_server_sink
+
+
+class qa_kiss_server_sink(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_instance(self):
+        """Tries to create a KISS server sink instance
+
+        It uses several combinations of parameters
+        """
+        kiss_server_sink('', 1234)
+        kiss_server_sink('127.0.0.1', 4567)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_kiss_server_sink)


### PR DESCRIPTION
The port parameter of the socket_pdu block should be an str. Using an int
instead gives an error under GNU Radio 3.9 (and probably 3.10), since
pybind11 insists that the type must be correct. I think that under
GNU Radio 3.8 (with swig), an int parameter was converted silently to
an str, so we saw no problems.

This fixes #342