### PR TITLE
fix UDP source in gr_satellites and GR 3.10

### DIFF
--- a/apps/gr_satellites
+++ b/apps/gr_satellites
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2020 Daniel Estevez <daniel@destevez.net>
+# Copyright 2019-2022 Daniel Estevez <daniel@destevez.net>
 #
 # This file is part of gr-satellites
 #
@@ -11,6 +11,11 @@
 import argparse
 import signal
 import sys
+
+
+if gr.api_version() != '9':
+    from gnuradio import network
+
 
 from gnuradio import gr, blocks, audio
 import satellites.core
@@ -260,13 +265,22 @@ class gr_satellites_top_block(gr.top_block):
     def setup_udp_input(self):
         if self.options.udp_raw:
             size = gr.sizeof_gr_complex if self.options.iq else gr.sizeof_float
-            self.input = blocks.udp_source(size, self.options.udp_ip,
-                                           self.options.udp_port, 1472, False)
+            self.input = self.udp_source(size)
         else:
-            self.input_int16 = blocks.udp_source(
-                gr.sizeof_short, self.options.udp_ip, self.options.udp_port,
-                1472, False)
+            self.input_int16 = self.udp_source(gr.sizeof_short)
             self.setup_input_int16()
+
+    def udp_source(self, size):
+        # The UDP source has been moved in GNU Radio 3.10
+        if gr.api_version() == '9':
+            return blocks.udp_source(
+                size, self.options.udp_ip, self.options.udp_port,
+                1472, False)
+        else:
+            udp_header = 0  # no header
+            return network.udp_source(
+                size, 1, self.options.udp_ip, self.options.udp_port,
+                udp_header, 1472, False)
 
     def setup_input_int16(self):
         self.short_to_float = blocks.short_to_float(1, 32767)

--- a/apps/gr_satellites
+++ b/apps/gr_satellites
@@ -273,13 +273,10 @@ class gr_satellites_top_block(gr.top_block):
         # The UDP source has been moved in GNU Radio 3.10
         if gr.api_version() == '9':
             return blocks.udp_source(
-                size, self.options.udp_ip, self.options.udp_port,
-                1472, False)
+                size, self.options.udp_ip, self.options.udp_port, 1472, False)
         else:
-            udp_header = 0  # no header
             return network.udp_source(
-                size, 1, self.options.udp_ip, self.options.udp_port,
-                udp_header, 1472, False)
+                size, 1, self.options.udp_port, 0, 1472, False, False, True)
 
     def setup_input_int16(self):
         self.short_to_float = blocks.short_to_float(1, 32767)

--- a/apps/gr_satellites
+++ b/apps/gr_satellites
@@ -12,12 +12,11 @@ import argparse
 import signal
 import sys
 
+from gnuradio import gr, blocks, audio
 
 if gr.api_version() != '9':
     from gnuradio import network
 
-
-from gnuradio import gr, blocks, audio
 import satellites.core
 import satellites.components.datasources as datasources
 from satellites.utils.config import open_config


### PR DESCRIPTION
The UDP source block has been moved to gr-network in GNU Radio 3.10.
This modifies gr_satellites to pull the block from the appropriate
location according to the version of GNU Radio.