### PR TITLE
Delete DSTAR-One telemetry parser from cmake

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -44,7 +44,6 @@ install(FILES
     satellites_decode_rs_ccsds.block.yml
     satellites_descrambler308.block.yml
     satellites_distributed_syncframe_soft.block.yml
-    satellites_dstar_one_telemetry_parser.block.yml
     satellites_encode_rs.block.yml
     satellites_encode_rs_ccsds.block.yml
     satellites_eseo_line_decoder.block.yml


### PR DESCRIPTION
The corresponding GRC file was removed in a previous commit (18684a6b9f5a446db2735ddb59f090d8558ec7d6), which breaks installation.

Signed-off-by: Clayton Smith <argilo@gmail.com>