### PR TITLE
Modernize logging and remove all usage of Boost

### DIFF
--- a/lib/crc_append_impl.cc
+++ b/lib/crc_append_impl.cc
@@ -82,7 +82,7 @@ void crc_append_impl::msg_handler(pmt::pmt_t pmt_msg)
 
     const auto size = msg.size();
     if (size <= d_header_bytes) {
-        GR_LOG_WARN(this->d_logger, "PDU too short; dropping");
+        this->d_logger->warn("PDU too short; dropping");
         return;
     }
 

--- a/lib/crc_check_impl.cc
+++ b/lib/crc_check_impl.cc
@@ -88,7 +88,7 @@ void crc_check_impl::msg_handler(pmt::pmt_t pmt_msg)
 
     const auto size = msg.size();
     if (size <= d_header_bytes + num_bytes) {
-        GR_LOG_WARN(this->d_logger, "PDU too short; dropping");
+        this->d_logger->warn("PDU too short; dropping");
         return;
     }
 
@@ -111,9 +111,9 @@ void crc_check_impl::msg_handler(pmt::pmt_t pmt_msg)
 
     const bool crc_ok = crc_computed == msg_crc;
     if (crc_ok) {
-        GR_LOG_INFO(this->d_logger, "CRC OK");
+        this->d_logger->info("CRC OK");
     } else {
-        GR_LOG_INFO(this->d_logger, "CRC fail");
+        this->d_logger->info("CRC fail");
     }
 
     const auto out_size = d_discard_crc ? size - num_bytes : size;

--- a/lib/decode_ra_code_impl.cc
+++ b/lib/decode_ra_code_impl.cc
@@ -79,7 +79,7 @@ void decode_ra_code_impl::msg_handler(pmt::pmt_t pmt_msg)
                 "message length: %ld, expected: %d\n",
                 (long)length,
                 ra_code_length * RA_BITCOUNT);
-        GR_LOG_ERROR(d_logger, "Invalid message length");
+        d_logger->error("Invalid message length");
         return;
     }
 

--- a/lib/encode_rs_impl.cc
+++ b/lib/encode_rs_impl.cc
@@ -15,7 +15,6 @@
 #include "encode_rs_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <boost/format.hpp>
 #include <algorithm>
 #include <exception>
 
@@ -92,8 +91,8 @@ encode_rs_impl::encode_rs_impl(
 void encode_rs_impl::check_interleave()
 {
     if (d_interleave <= 0) {
-        throw std::runtime_error(
-            boost::str(boost::format("Invalid interleave value = %d") % d_interleave));
+        throw std::runtime_error("Invalid interleave value = " +
+                                 std::to_string(d_interleave));
     }
 }
 
@@ -129,23 +128,22 @@ void encode_rs_impl::msg_handler(pmt::pmt_t pmt_msg)
     auto msg = pmt::u8vector_elements(pmt::cdr(pmt_msg));
 
     if (msg.size() % d_interleave != 0) {
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format("Reed-Solomon message size not divisible by interleave "
-                          "depth. size = %d, interleave = %d") %
-                msg.size() % d_interleave);
+        d_logger->error("Reed-Solomon message size not divisible by interleave "
+                        "depth. size = {:d}, interleave = {:d}",
+                        msg.size(),
+                        d_interleave);
         return;
     }
 
     int rs_kk = msg.size() / d_interleave;
 
     if ((unsigned)(rs_kk + d_nroots) > d_rs_codeword.size()) {
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format("Reed-Solomon message too large. size = %d, interleave "
-                          "= %d, RS code (%d, %d)") %
-                msg.size() % d_interleave % d_rs_codeword.size() %
-                (d_rs_codeword.size() - d_nroots));
+        d_logger->error("Reed-Solomon message too large. size = {:d}, interleave "
+                        "= {:d}, RS code ({:d}, {:d})",
+                        msg.size(),
+                        d_interleave,
+                        d_rs_codeword.size(),
+                        d_rs_codeword.size() - d_nroots);
         return;
     }
 

--- a/lib/nusat_decoder_impl.cc
+++ b/lib/nusat_decoder_impl.cc
@@ -118,15 +118,15 @@ void nusat_decoder_impl::msg_handler(pmt::pmt_t pmt_msg)
     // Reed-Solomon decoding
     auto rs_res = decode_rs_char(d_rs, d_data.data(), NULL, 0);
     if (rs_res < 0) {
-        GR_LOG_INFO(d_logger, "Reed-Solomon decoding failed");
+        d_logger->info("Reed-Solomon decoding failed");
         return;
     } else {
-        GR_LOG_INFO(d_logger, "Reed-Solomon decoding OK");
+        d_logger->info("Reed-Solomon decoding OK");
     }
 
     length = d_data[d_len_byte];
     if (length >= msg_length - d_header_len) {
-        GR_LOG_INFO(d_logger, "Length field corrupted");
+        d_logger->info("Length field corrupted");
         return;
     }
 
@@ -138,7 +138,7 @@ void nusat_decoder_impl::msg_handler(pmt::pmt_t pmt_msg)
 
     // Compute CRC-8
     if (crc8(packet, length) != d_data[d_crc_byte]) {
-        GR_LOG_INFO(d_logger, "CRC-8 does not match");
+        d_logger->info("CRC-8 does not match");
         return;
     }
 

--- a/lib/varlen_packet_framer_impl.cc
+++ b/lib/varlen_packet_framer_impl.cc
@@ -14,7 +14,6 @@
 
 #include "varlen_packet_framer_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <ctime>
 #include <iostream>
@@ -158,9 +157,8 @@ int varlen_packet_framer_impl::general_work(int noutput_items,
             std::cout << "\tread: " << nitems_read(0) << "\tini:  " << ninput_items[0]
                       << "\touti: " << noutput_items << std::endl;
 #endif
-            GR_LOG_DEBUG(d_debug_logger,
-                         boost::format("%d byte packet output @ %ld") % packet_len %
-                             nitems_written(0));
+            d_debug_logger->debug(
+                "{:d} byte packet output @ {:d}", packet_len, nitems_written(0));
             d_ninput_items_required = 1; // d_header_length + asm_len + 1; // abs min
             return packet_len + d_header_length + asm_len;
         } else {

--- a/lib/varlen_packet_tagger_impl.cc
+++ b/lib/varlen_packet_tagger_impl.cc
@@ -14,7 +14,6 @@
 
 #include "varlen_packet_tagger_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <iostream>
 extern "C" {
@@ -113,7 +112,7 @@ int varlen_packet_tagger_impl::general_work(int noutput_items,
             if (golay_res >= 0) {
                 packet_len = 8 * (0xFFF & golay_field);
             } else {
-                GR_LOG_WARN(d_debug_logger, "Golay decode failed.");
+                d_debug_logger->warn("Golay decode failed.");
                 d_have_sync = false;
                 consume_each(1); // skip ahead
                 return 0;
@@ -124,8 +123,7 @@ int varlen_packet_tagger_impl::general_work(int noutput_items,
         }
 
         if (packet_len > d_mtu) {
-            GR_LOG_WARN(d_debug_logger,
-                        boost::format("Packet length %d > mtu %d.") % packet_len % d_mtu);
+            d_debug_logger->warn("Packet length {:d} > mtu {:d}.", packet_len, d_mtu);
             d_have_sync = false;
             consume_each(1); // skip ahead
             return 0;
@@ -142,13 +140,13 @@ int varlen_packet_tagger_impl::general_work(int noutput_items,
         if (ninput_items[0] >= packet_len + d_header_length) {
 
             if (d_use_golay) {
-                GR_LOG_DEBUG(d_debug_logger,
-                             boost::format("Header: 0x%06x, Len: %d") %
-                                 (0xFFFFFF & golay_field) % (0xFFF & packet_len));
+                d_debug_logger->debug("Header: {#06x}, Len: {:d}",
+                                      0xFFFFFF & golay_field,
+                                      0xFFF & packet_len);
                 if (golay_res >= 0) {
-                    GR_LOG_DEBUG(d_debug_logger,
-                                 boost::format("Golay decoded. Errors: %d, Length: %d") %
-                                     golay_res % packet_len);
+                    d_debug_logger->debug("Golay decoded. Errors: {:d}, Length: {:d}",
+                                          golay_res,
+                                          packet_len);
                 }
             }
 


### PR DESCRIPTION
GNU Radio's logging framework now uses fmtlib instead of Boost.Format. GNU radio is also moving away from logging macros. I've updated logging here to match GNU Radio conventions.

I also switched a couple other instances of boost::format to standard C++.

Signed-off-by: Clayton Smith <argilo@gmail.com>