### PR TITLE
Add YML file for AzaadiSAT

### DIFF
--- a/python/satyaml/AzaadiSAT.yml
+++ b/python/satyaml/AzaadiSAT.yml
@@ -1,0 +1,15 @@
+name: AzaadiSAT
+norad: 99999
+data:
+  &tlm Telemetry:
+    unknown
+transmitters:
+  1k2 AFSK downlink:
+    frequency: 437.400e+6
+    modulation: AFSK
+    baudrate: 1200
+    af_carrier: 3625
+    deviation: -625
+    framing: AX.25
+    data:
+    - *tlm


### PR DESCRIPTION
ISRO launch scheduled for 7-Aug-2022

Details:  https://community.libre.space/t/sslv-d1-eos2-azaadisat-mission/9478/

Using SX1268 chip, multiple modes (LoRa, SSTV, CW, FSK).      Using FSK test audio file provided by the Project Team, was able to determine non-standard FSK (really AFSK, I think) tones which are reflected in this YML file.   

Sample audio file & decode text available at ->  https://www.qsl.net/k/k4kdr//audio/azaadisat/

Only tested in 'maint-3.8' branch; I assume this would be compatible with other branches but only tested in 'maint-3.8'