### PR TITLE
Update GEOSCAN-EDELVEIS.yml

### DIFF
--- a/python/satyaml/GEOSCAN-EDELVEIS.yml
+++ b/python/satyaml/GEOSCAN-EDELVEIS.yml
@@ -7,10 +7,10 @@ data:
    &tlm Telemetry:
      unknown
 transmitters:
-   8k FSK downlink:
+   9k6 FSK downlink:
      frequency: 436.200e+6
      modulation: FSK
-     baudrate: 8000
+     baudrate: 9600
      framing: GEOSCAN
      data:
      - *tlm


### PR DESCRIPTION
Due to possible IQ replay sample rate issues it seems to be the reason we first thought it was 8k and not 9k6.
After receiving a good AF recording from DK3WN and using this for a replay, it seems the sample rate should be 9k6.

```
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 9k6 FSK downlink))
pdu_length = 64
contents = 
0000: 01 00 29 02 20 ff ff ff ff ff ff ff ff ff ff ff 
0010: ff ff ff ff ff ff ff ff ff 60 eb 06 5a 23 f5 0a 
0020: 05 0c 07 80 gr::log :INFO: crc_check0 - CRC OK
07 01 02 00 02 00 00 00 00 00 00 00 
0030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
***********************************
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 9k6 FSK downlink))
pdu_length = 64
contents = 
0000: 01 00 29 02 20 ff ff ff ff ff ff ff ff ff ff ff 
0010: ff ff ff ff ff ff ff ff ff 66 ec 06 5a 24 f5 0a 
0020: 05 0c 07 80 07 01 02 00 02 00 00 00 00 00 00 00 
0030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
***********************************

```