### PR TITLE
Fix SWIG bindings for Doppler correction block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Python bindings for 8APSK Costas Loop
+- Python bindings for Doppler correction block under GNU Radio 3.8
 
 ## [5.0.0], [4.7.0], [3.14.0] - 2022-07-22
 

--- a/include/satellites/doppler_correction.h
+++ b/include/satellites/doppler_correction.h
@@ -54,7 +54,7 @@ public:
      * \param samp_rate Sample rate
      * \param t0 Timestamp corresponding to the first sample
      */
-    static sptr make(std::string& filename, double samp_rate, double t0);
+    static sptr make(const char* filename, double samp_rate, double t0);
 };
 
 } // namespace satellites

--- a/lib/doppler_correction_impl.cc
+++ b/lib/doppler_correction_impl.cc
@@ -18,14 +18,14 @@ namespace gr {
 namespace satellites {
 
 doppler_correction::sptr
-doppler_correction::make(std::string& filename, double samp_rate, double t0)
+doppler_correction::make(const char* filename, double samp_rate, double t0)
 {
     return gnuradio::get_initial_sptr(
         new doppler_correction_impl(filename, samp_rate, t0));
 }
 
 
-doppler_correction_impl::doppler_correction_impl(std::string& filename,
+doppler_correction_impl::doppler_correction_impl(const char* filename,
                                                  double samp_rate,
                                                  double t0)
     : gr::sync_block("doppler_correction",
@@ -43,7 +43,7 @@ doppler_correction_impl::doppler_correction_impl(std::string& filename,
 
 doppler_correction_impl::~doppler_correction_impl() {}
 
-void doppler_correction_impl::read_doppler_file(std::string& filename)
+void doppler_correction_impl::read_doppler_file(const char* filename)
 {
     std::ifstream input_file(filename);
     double time;

--- a/lib/doppler_correction_impl.h
+++ b/lib/doppler_correction_impl.h
@@ -39,10 +39,10 @@ private:
             d_phase += 2 * GR_M_PI;
     }
 
-    void read_doppler_file(std::string& filename);
+    void read_doppler_file(const char* filename);
 
 public:
-    doppler_correction_impl(std::string& filename, double samp_rate, double t0);
+    doppler_correction_impl(const char* filename, double samp_rate, double t0);
     ~doppler_correction_impl();
 
     int work(int noutput_items,


### PR DESCRIPTION
The Doppler correction block used a std::string& parameter to indicate
the filename, but this gives problems with the SWIG bindings. Therefore,
we use const char* instead.

This fixes #398