### PR TITLE
Add EIRSAT-1 SatYAML

### DIFF
--- a/python/satyaml/EIRSAT-1.yml
+++ b/python/satyaml/EIRSAT-1.yml
@@ -1,0 +1,29 @@
+name: EIRSAT-1
+norad: 99320
+data:
+  &tlm Telemetry:
+    unknown
+transmitters:
+  9k6 GMSK convolutional downlink:
+    frequency: 437.100e+6
+    modulation: FSK
+    baudrate: 9600
+    framing: CCSDS Concatenated
+    frame size: 892
+    RS basis: dual 
+    RS interleaving: 4
+    convolutional: CCSDS uninverted
+    deviation: -2400
+    data:
+    - *tlm
+  9k6 GMSK downlink:
+    frequency: 437.100e+6
+    modulation: FSK
+    baudrate: 9600
+    framing: CCSDS Reed-Solomon
+    frame size: 892
+    RS basis: dual 
+    RS interleaving: 4
+    deviation: -2400
+    data:
+    - *tlm


### PR DESCRIPTION
This is based on the following SatYAML file:
https://github.com/ucd-eirsat-1/beacon/blob/9b86d6756b73f63eb107ea5b70e53e53375474c1/SatYAML/EIRSAT-1.yml

I have added the temporary SatNOGS ID and the negative deviation to represent the fact that the transmitter send the bit 1 as the low FSK tone.