### PR TITLE
Update CYCLOPS.yml

### DIFF
--- a/python/satyaml/CYCLOPS.yml
+++ b/python/satyaml/CYCLOPS.yml
@@ -8,31 +8,31 @@ data:
   &tlm Telemetry:
     telemetry: ax25
 transmitters:
-  1k2 FSK G3RUH downlink:
+  1k2 FSK USP downlink:
     frequency: 436.050e+6
     modulation: FSK
     baudrate: 1200
-    framing: AX.25 G3RUH
+    framing: USP
     data:
     - *tlm
-  2k4 FSK G3RUH downlink:
+  2k4 FSK USP downlink:
     frequency: 436.050e+6
     modulation: FSK
     baudrate: 2400
-    framing: AX.25 G3RUH
+    framing: USP
     data:
     - *tlm
-  4k8 FSK G3RUH downlink:
+  4k8 FSK USP downlink:
     frequency: 436.050e+6
     modulation: FSK
     baudrate: 4800
-    framing: AX.25 G3RUH
+    framing: USP
     data:
     - *tlm
-  9k6 FSK G3RUH downlink:
+  9k6 FSK USP downlink:
     frequency: 436.050e+6
     modulation: FSK
     baudrate: 9600
-    framing: AX.25 G3RUH
+    framing: USP
     data:
     - *tlm


### PR DESCRIPTION
After some investigation it seems we made a framing mistake when creating this yml file, the framing should be USP. Use the following observation to test the changed yml https://network.satnogs.org/observations/7141233/

```
-> Packet from 2k4 FSK USP downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'R2ANF' (total 5)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'RS29S' (total 5)
                ssid = Container: 
                    ch = False
                    ssid = 1
                    extension = True
        control = 0x00
        pid = 0xF0
    info = b'\x16B\x02\x00\x01\x00B\x00\t\x00\r\x00\x04\x00\x00\x00\x03\x00\x00\x00\xe9\xff\x00\x00\x1c\x00\x00\x00\x00\x00\x08\x00\x08\x00\x08\x00\t\x00\x00 \x00\x00\xc0\x1eb1\x00\x00\xb0\x11\xe8c\xfe\x04\x0e\x0c\xff| \x07\xdf\x0e\xb0\x11\xe8cV1\x00\x00\x1e\x00\xe4\x1e' (total 74)
```