### PR TITLE
Add getters/setters to doppler_correction

### DIFF
--- a/include/satellites/doppler_correction.h
+++ b/include/satellites/doppler_correction.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2022 Daniel Estevez <daniel@destevez.net>.
+ * Copyright 2022-2023 Daniel Estevez <daniel@destevez.net>.
  *
  * This file is part of gr-satellites
  *
@@ -55,6 +55,23 @@ public:
      * \param t0 Timestamp corresponding to the first sample
      */
     static sptr make(std::string& filename, double samp_rate, double t0);
+
+    /*!
+     * \brief Sets the current time.
+     *
+     * \param t Tiemstamp corresponding to the current time.
+     */
+    virtual void set_time(double t) = 0;
+
+    /*!
+     * \brief Returns the current time.
+     */
+    virtual double time() = 0;
+
+    /*!
+     * \brief Returns the current frequency in Hz.
+     */
+    virtual double frequency() = 0;
 };
 
 } // namespace satellites

--- a/lib/doppler_correction_impl.cc
+++ b/lib/doppler_correction_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2022 Daniel Estevez <daniel@destevez.net>.
+ * Copyright 2022-2023 Daniel Estevez <daniel@destevez.net>.
  *
  * This file is part of gr-satellites
  *
@@ -35,7 +35,9 @@ doppler_correction_impl::doppler_correction_impl(std::string& filename,
       d_current_index(0),
       d_t0(t0),
       d_sample_t0(0),
-      d_rx_time_key(pmt::mp("rx_time"))
+      d_rx_time_key(pmt::mp("rx_time")),
+      d_current_time(t0),
+      d_current_freq(0.0)
 {
     read_doppler_file(filename);
 }
@@ -56,12 +58,24 @@ void doppler_correction_impl::read_doppler_file(std::string& filename)
         times.push_back(time);
         freqs_rad_per_sample.push_back(2.0 * GR_M_PI * frequency / d_samp_rate);
     }
+    if (freqs_rad_per_sample.size() >= 1) {
+        d_current_freq = freqs_rad_per_sample[0];
+    }
+}
+
+void doppler_correction_impl::set_time(double t)
+{
+    gr::thread::scoped_lock guard(d_setlock);
+    d_sample_t0 = nitems_written(0);
+    d_t0 = t;
+    d_logger->info("set time {} at sample {}", d_t0, d_sample_t0);
 }
 
 int doppler_correction_impl::work(int noutput_items,
                                   gr_vector_const_void_star& input_items,
                                   gr_vector_void_star& output_items)
 {
+    gr::thread::scoped_lock guard(d_setlock);
     auto in = static_cast<const gr_complex*>(input_items[0]);
     auto out = static_cast<gr_complex*>(output_items[0]);
 
@@ -75,14 +89,15 @@ int doppler_correction_impl::work(int noutput_items,
         }
     }
 
+    double time = 0.0;
+    double freq = 0.0;
     for (int j = 0; j < noutput_items; ++j) {
-        double time = d_t0 + (nitems_written(0) - d_sample_t0 + j) / d_samp_rate;
+        time = d_t0 + (nitems_written(0) - d_sample_t0 + j) / d_samp_rate;
         // Advance d_current_index so that the next time is greater than the
         // current.
         while (d_current_index + 1 < times.size() && times[d_current_index + 1] <= time) {
             ++d_current_index;
         }
-        double freq;
         if ((time < times[d_current_index]) || (d_current_index + 1 == times.size())) {
             // We are before the beginning or past the end of the file, so we
             // maintain a constant frequency.
@@ -99,6 +114,9 @@ int doppler_correction_impl::work(int noutput_items,
         const gr_complex nco = gr_expj(-d_phase);
         gr::fast_cc_multiply(out[j], in[j], nco);
     }
+
+    d_current_freq = freq;
+    d_current_time = time;
 
     return noutput_items;
 }

--- a/lib/doppler_correction_impl.h
+++ b/lib/doppler_correction_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2022 Daniel Estevez <daniel@destevez.net>.
+ * Copyright 2022-2023 Daniel Estevez <daniel@destevez.net>.
  *
  * This file is part of gr-satellites
  *
@@ -29,6 +29,8 @@ private:
     std::vector<double> freqs_rad_per_sample;
     std::vector<tag_t> d_tags;
     const pmt::pmt_t d_rx_time_key;
+    double d_current_time;
+    double d_current_freq;
 
     // Implementation taken from gr::block::control_loop
     void phase_wrap()
@@ -43,11 +45,25 @@ private:
 
 public:
     doppler_correction_impl(std::string& filename, double samp_rate, double t0);
-    ~doppler_correction_impl();
+    ~doppler_correction_impl() override;
+
+    void set_time(double) override;
+
+    double time() override
+    {
+        gr::thread::scoped_lock guard(d_setlock);
+        return d_current_time;
+    }
+
+    double frequency() override
+    {
+        gr::thread::scoped_lock guard(d_setlock);
+        return d_current_freq * d_samp_rate / (2.0 * GR_M_PI);
+    }
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items);
+             gr_vector_void_star& output_items) override;
 };
 
 } // namespace satellites

--- a/python/bindings/docstrings/doppler_correction_pydoc_template.h
+++ b/python/bindings/docstrings/doppler_correction_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -18,8 +18,21 @@
 static const char* __doc_gr_satellites_doppler_correction = R"doc()doc";
 
 
-static const char* __doc_gr_satellites_doppler_correction_doppler_correction =
+static const char* __doc_gr_satellites_doppler_correction_doppler_correction_0 =
+    R"doc()doc";
+
+
+static const char* __doc_gr_satellites_doppler_correction_doppler_correction_1 =
     R"doc()doc";
 
 
 static const char* __doc_gr_satellites_doppler_correction_make = R"doc()doc";
+
+
+static const char* __doc_gr_satellites_doppler_correction_set_time = R"doc()doc";
+
+
+static const char* __doc_gr_satellites_doppler_correction_time = R"doc()doc";
+
+
+static const char* __doc_gr_satellites_doppler_correction_frequency = R"doc()doc";

--- a/python/bindings/doppler_correction_python.cc
+++ b/python/bindings/doppler_correction_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(doppler_correction.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2f8dcd8094f394be084fcc883e9189f9)                     */
+/* BINDTOOL_HEADER_FILE_HASH(56444490a7f522137e132976be778b10)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -46,6 +46,18 @@ void bind_doppler_correction(py::module& m)
              py::arg("t0"),
              D(doppler_correction, make))
 
+
+        .def("set_time",
+             &doppler_correction::set_time,
+             py::arg("t"),
+             D(doppler_correction, set_time))
+
+
+        .def("time", &doppler_correction::time, D(doppler_correction, time))
+
+
+        .def(
+            "frequency", &doppler_correction::frequency, D(doppler_correction, frequency))
 
         ;
 }


### PR DESCRIPTION
This adds getter methods for the current time and frequency and a setter method for the current time to the doppler_correction block.

(cherry picked from commit bb8d43675818ecdba5db31579cd458fb7c5d63dc)