### PR TITLE
Add getters/setters to doppler_correction

### DIFF
--- a/include/satellites/doppler_correction.h
+++ b/include/satellites/doppler_correction.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2022 Daniel Estevez <daniel@destevez.net>.
+ * Copyright 2022-2023 Daniel Estevez <daniel@destevez.net>.
  *
  * This file is part of gr-satellites
  *
@@ -55,6 +55,23 @@ public:
      * \param t0 Timestamp corresponding to the first sample
      */
     static sptr make(const char* filename, double samp_rate, double t0);
+
+    /*!
+     * \brief Sets the current time.
+     *
+     * \param t Tiemstamp corresponding to the current time.
+     */
+    virtual void set_time(double t) = 0;
+
+    /*!
+     * \brief Returns the current time.
+     */
+    virtual double time() = 0;
+
+    /*!
+     * \brief Returns the current frequency in Hz.
+     */
+    virtual double frequency() = 0;
 };
 
 } // namespace satellites

--- a/lib/doppler_correction_impl.h
+++ b/lib/doppler_correction_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2022 Daniel Estevez <daniel@destevez.net>.
+ * Copyright 2022-2023 Daniel Estevez <daniel@destevez.net>.
  *
  * This file is part of gr-satellites
  *
@@ -29,6 +29,8 @@ private:
     std::vector<double> freqs_rad_per_sample;
     std::vector<tag_t> d_tags;
     const pmt::pmt_t d_rx_time_key;
+    double d_current_time;
+    double d_current_freq;
 
     // Implementation taken from gr::block::control_loop
     void phase_wrap()
@@ -45,9 +47,23 @@ public:
     doppler_correction_impl(const char* filename, double samp_rate, double t0);
     ~doppler_correction_impl();
 
+    void set_time(double) override;
+
+    double time() override
+    {
+        gr::thread::scoped_lock guard(d_setlock);
+        return d_current_time;
+    }
+
+    double frequency() override
+    {
+        gr::thread::scoped_lock guard(d_setlock);
+        return d_current_freq * d_samp_rate / (2.0 * GR_M_PI);
+    }
+
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items);
+             gr_vector_void_star& output_items) override;
 };
 
 } // namespace satellites


### PR DESCRIPTION
This adds getter methods for the current time and frequency and a setter method for the current time to the doppler_correction block.

(cherry picked from commit bb8d43675818ecdba5db31579cd458fb7c5d63dc)