### PR TITLE
Make HDLC Framer pass the metadata from the input pdu to the output pdu

### DIFF
--- a/python/hdlc_framer.py
+++ b/python/hdlc_framer.py
@@ -34,6 +34,7 @@ class hdlc_framer(gr.basic_block):
         self.message_port_register_out(pmt.intern('out'))
 
     def handle_msg(self, msg_pmt):
+        meta = pmt.car(msg_pmt)
         msg = pmt.cdr(msg_pmt)
         if not pmt.is_u8vector(msg):
             print('[ERROR] Received invalid message type. Expected u8vector')
@@ -64,4 +65,4 @@ class hdlc_framer(gr.basic_block):
 
         self.message_port_pub(
             pmt.intern('out'),
-            pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(len(buff), buff)))
+            pmt.cons(meta, pmt.init_u8vector(len(buff), buff)))


### PR DESCRIPTION
This allows setting the "tx_time" attribute that is required by some SDRs to time the transmission of a burst (e.g. the LimeSDR) in the block that generates the data to be HDLC encoded (since PDU to tagged stream applies all the metadata keys of the pdu as additional tags on the first sample).

If there is a use case for having this block explicitly not propagate metadata, I can add a configuration parameter to enable this new behavior conditionally.