### PR TITLE
Changed CSP packet id to network endian

### DIFF
--- a/python/csp_header.py
+++ b/python/csp_header.py
@@ -15,7 +15,7 @@ class CSP(object):
     def __init__(self, csp_packet):
         if len(csp_packet) < 4:
             raise ValueError('Malformed CSP packet (too short)')
-        csp = struct.unpack('<I', csp_packet[0:4])[0]
+        csp = struct.unpack('!I', csp_packet[0:4])[0]
         self.priority = (csp >> 30) & 0x3
         self.source = (csp >> 25) & 0x1f
         self.destination = (csp >> 20) & 0x1f


### PR DESCRIPTION
In libcsp the Header ID is encoded as network/big-endian for csp 1 and csp 2.0:

Refer to:
- https://github.com/libcsp/libcsp/blob/6f81c3da04c051c35ed6c28612a4037c031bb1f3/src/csp_id.c#L42-L59
- https://github.com/libcsp/libcsp/blob/6f81c3da04c051c35ed6c28612a4037c031bb1f3/src/csp_id.c#L123-L141