### PR TITLE
BME WebSocket telmetry submitter (maint-3.8 branch)

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-      - uses: daniestevez/gr-satellites-ci-action@v0.1.3
+      - uses: daniestevez/gr-satellites-ci-action@v0.1.4

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends: cmake,
                python3-six,
                swig,
                python3-construct,
-               python3-requests
+               python3-requests,
+	       python3-websocket
 Standards-Version: 4.5.0
 Homepage: http://github.com/daniestevez/gr-satellites
 Vcs-Git: git://github.com/daniestevez/gr-satellites.git
@@ -25,7 +26,8 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${python3:Depends}, ${shlibs:Depends},
          gnuradio,
          python3-construct,
-	 python3-requests
+	 python3-requests,
+	 python3-websocket
 Recommends: feh
 Description:GNU Radio out-of-tree module with Amateur satellite decoders.
  gr-satellites is a GNU Radio out-of-tree module that contains a collection of

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -497,7 +497,10 @@ certain satellite projects:
 
 * `PW-Sat2 Groundstation`_, which is used by PW-Sat2.
 
-* The `BME telemetry server`_, which is used by SMOG-P, ATL-1 and SMOG-1.
+* The `BME telemetry server`_, which is used by SMOG-P, ATL-1 and SMOG-1. (This
+  server is deprecated, since it is not used anymore by BME).
+
+* The `BME telemetry server (WebSocket)`_, which is used by MRC-100.
 
 * `Harbin Institute of Technology`_, which connects to the telemetry proxy included in
   `gr-lilacsat`_ and `gr-dslwp`_.
@@ -550,6 +553,9 @@ have an account registered in the server to obtain the credentials file.
 To enable telemetry submission to the BME server, it is necessary to
 `register an account in the BME server`_. The user and password should be
 entered into the gr-satellites ``.ini`` file.
+
+The BME server (WebSocket) does not require any registration or additional
+configuration.
 
 To use the Harbin Institute of Technology proxy to submit telemetry, the proxy
 needs to be run and started in the local computer before running
@@ -777,6 +783,7 @@ Example:
 .. _FUNcube Warehouse: http://warehouse.funcube.org.uk/
 .. _PW-Sat2 Groundstation: https://radio.pw-sat.pl/
 .. _BME telemetry server: https://gnd.bme.hu:8080/
+.. _BME telemetry server (WebSocket): https://gnd.bme.hu/
 .. _registering in the warehouse: http://warehouse.funcube.org.uk/registration
 .. _Your credentials: https://radio.pw-sat.pl/communication/yourcredentials
 .. _register an account in the BME server: https://gnd.bme.hu:8080/auth/register

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -34,6 +34,7 @@ Additionally, the following Python packages are required:
 
 * `construct`_, at least version 2.9.
 * `requests`_
+* `websocket-client`_
 
 .. note::
    construct and requests can be installed with `pip`_
@@ -49,6 +50,7 @@ Additionally, the following Python packages are required:
 .. _GNU Radio: https://gnuradio.org/
 .. _construct: https://construct.readthedocs.io/en/latest/
 .. _requests: https://pypi.org/project/requests/
+.. _websocket-client: https://pypi.org/project/websocket-client/
 .. _pip: https://pypi.org/project/pip/
 .. _gr-satellites README: https://github.com/daniestevez/gr-satellites/blob/main/README.md
 

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -25,6 +25,7 @@ install(FILES
     satellites_ax100_decode.block.yml
     satellites_beesat_classifier.block.yml
     satellites_bme_submitter.block.yml
+    satellites_bme_ws_submitter.block.yml
     satellites_cc11xx_packet_crop.block.yml
     satellites_check_address.block.yml
     satellites_check_ao40_uncoded_crc.block.yml

--- a/grc/components/datasinks/satellites_telemetry_submit.block.yml
+++ b/grc/components/datasinks/satellites_telemetry_submit.block.yml
@@ -7,8 +7,8 @@ parameters:
     label: Server
     dtype: enum
     default: '"SatNOGS"'
-    options: ['"SatNOGS"', '"FUNcube"', '"PWSat"', '"BME"', '"HIT"', '"SIDS"']
-    option_labels: [SatNOGS DB, AMSAT-UK Data Warehouse, PW-Sat2 Ground Station, BME Ground Station, Harbin Institute of Technology, Custom SIDS server]
+    options: ['"SatNOGS"', '"FUNcube"', '"PWSat"', '"BME"', '"BMEWS"', '"HIT"', '"SIDS"']
+    option_labels: [SatNOGS DB, AMSAT-UK Data Warehouse, PW-Sat2 Ground Station, BME Ground Station (Deprecated), BME Ground Station (WebSocket), Harbin Institute of Technology, Custom SIDS server]
 -   id: url
     label: URL
     dtype: string

--- a/grc/satellites_bme_submitter.block.yml
+++ b/grc/satellites_bme_submitter.block.yml
@@ -1,6 +1,6 @@
 id: satellites_bme_submitter
-label: BME Telemetry Forwarder
-category: '[Satellites]/Misc'
+label: BME Telemetry Forwarder (Deprecated)
+category: '[Satellites]/Deprecated'
 
 parameters:
 -   id: user

--- a/grc/satellites_bme_ws_submitter.block.yml
+++ b/grc/satellites_bme_ws_submitter.block.yml
@@ -1,0 +1,13 @@
+id: satellites_bme_ws_submitter
+label: BME Telemetry Forwarder (WebSocket)
+category: '[Satellites]/Misc'
+
+inputs:
+-   domain: message
+    id: in
+
+templates:
+    imports: import satellites
+    make: satellites.bme_submitter()
+
+file_format: 1

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -40,6 +40,7 @@ GR_PYTHON_INSTALL(
     bch15.py
     beesat_classifier.py
     bme_submitter.py
+    bme_ws_submitter.py
     cc11xx_packet_crop.py
     check_address.py
     check_ao40_uncoded_crc.py

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -50,6 +50,7 @@ from .adsb_kml import adsb_kml
 from .append_crc32c import append_crc32c
 from .beesat_classifier import beesat_classifier
 from .bme_submitter import bme_submitter
+from .bme_ws_submitter import bme_ws_submitter
 from .cc11xx_packet_crop import cc11xx_packet_crop
 from .check_address import check_address
 from .check_ao40_uncoded_crc import check_ao40_uncoded_crc

--- a/python/bme_ws_submitter.py
+++ b/python/bme_ws_submitter.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2023 Daniel Estevez <daniel@destevez.net>
+#
+# This file is part of gr-satellites
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+
+from gnuradio import gr
+import pmt
+import websocket
+
+
+class bme_ws_submitter(gr.basic_block):
+    """
+    Submits telemetry to wss://gnd.bme.hu:8070/send
+    """
+    def __init__(self):
+        gr.basic_block.__init__(
+            self,
+            name='bme_ws_submitter',
+            in_sig=[],
+            out_sig=[])
+
+        self.ws = websocket.WebSocket()
+        url = 'wss://gnd.bme.hu:8070/send'
+        try:
+            self.ws.connect(url)
+        except Exception:
+            print(f'could not connect to {url}; '
+                  'disabling telemetry submission')
+            self.ws = None
+
+        self.message_port_register_in(pmt.intern('in'))
+        self.set_msg_handler(pmt.intern('in'), self.handle_msg)
+
+    def __del__(self):
+        if self.ws is not None:
+            self.ws.close()
+
+    def submit(self, frame):
+        if self.ws is None:
+            return
+        data = f'"data": "{frame.hex().upper()}"'
+        self.ws.send(data)
+        response = self.ws.recv()
+        response = json.loads('{' + response + '}')
+        error = any([v != 0 for k, v in response.items()
+                     if 'error' in k])
+        if error:
+            print(f'server did not accept frame; returned: {response}')
+
+    def handle_msg(self, msg_pmt):
+        msg = pmt.cdr(msg_pmt)
+        if not pmt.is_u8vector(msg):
+            print('[ERROR] Received invalid message type. Expected u8vector')
+            return
+
+        frame = bytes(pmt.u8vector_elements(msg))
+        try:
+            self.submit(frame)
+        except Exception as e:
+            print(f'failed to submit frame: {e}')

--- a/python/components/datasinks/telemetry_submit.py
+++ b/python/components/datasinks/telemetry_submit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2019 Daniel Estevez <daniel@destevez.net>
+# Copyright 2019,2023 Daniel Estevez <daniel@destevez.net>
 #
 # This file is part of gr-satellites
 #
@@ -11,7 +11,7 @@
 from gnuradio import gr, blocks
 
 from ... import submit, funcube_submit
-from ... import pwsat2_submitter, bme_submitter, pdu_to_kiss
+from ... import pwsat2_submitter, bme_submitter, bme_ws_submitter, pdu_to_kiss
 from ...utils.options_block import options_block
 
 
@@ -24,7 +24,8 @@ class telemetry_submit(gr.hier_block2, options_block):
     These are submitted to a telemetry server
 
     Args:
-        server: 'SatNOGS', 'FUNcube', 'PWSat', 'BME' or 'SIDS' (string)
+        server: 'SatNOGS', 'FUNcube', 'PWSat', 'BME', 'BMEWS'
+            or 'SIDS' (string)
         norad: NORAD ID (int)
         port: TCP port to connect to (used by HIT) (str)
         url: SIDS URL (used by SIDS) (str)
@@ -64,6 +65,8 @@ class telemetry_submit(gr.hier_block2, options_block):
             satellite = satellites[norad]
             self.submit = bme_submitter(
                 config['BME']['user'], config['BME']['password'], satellite)
+        elif server == 'BMEWS':
+            self.submit = bme_ws_submitter()
         elif server == 'HIT':
             try:
                 self.tcp = blocks.socket_pdu(

--- a/python/satyaml/MRC-100.yml
+++ b/python/satyaml/MRC-100.yml
@@ -1,5 +1,7 @@
 name: MRC-100
 norad: 99182
+telemetry_servers:
+  - BMEWS
 data:
   &tlm Telemetry:
     unknown

--- a/python/satyaml/satyaml.py
+++ b/python/satyaml/satyaml.py
@@ -65,7 +65,8 @@ class SatYAML:
             raise YAMLError(f'NORAD field does not contain a number in {yml}')
         if 'telemetry_servers' in d:
             for server in d['telemetry_servers']:
-                if (server not in ['SatNOGS', 'FUNcube', 'PWSat', 'BME']
+                if (server not in ['SatNOGS', 'FUNcube', 'PWSat', 'BME',
+                                   'BMEWS']
                         and not server.startswith('HIT ')
                         and not server.startswith('SIDS ')):
                     raise YAMLError(f'Unknown telemetry server {server}')


### PR DESCRIPTION
This adds support for sending telemetry to the BME WebSocket server, which is used by MRC-100.

The implementation uses the Python websocket-client package (Debian /Ubuntu package python3-websocket), which has been added as a dependency in the installation instructions in the documentation and in the debian package control file. The build-ubuntu CI action has been updated to include python3-websocket in the Docker image.

The older BME HTTP telemetry server has been marked as deprecated, since it is no longer operational.