### PR TITLE
Update AzaadiSAT.yml

### DIFF
--- a/python/satyaml/AzaadiSAT.yml
+++ b/python/satyaml/AzaadiSAT.yml
@@ -1,5 +1,7 @@
 name: AzaadiSAT
-norad: 99999
+alternative_names:
+  - EPDM-0969-2670-9539-4005
+norad: 99355
 data:
   &tlm Telemetry:
     telemetry: ax25

--- a/python/satyaml/AzaadiSAT.yml
+++ b/python/satyaml/AzaadiSAT.yml
@@ -1,6 +1,4 @@
 name: AzaadiSAT
-alternative_names:
-  - EPDM-0969-2670-9539-4005
 norad: 99355
 data:
   &tlm Telemetry:


### PR DESCRIPTION
Changed the Norad-ID to the SatNOGS temporary and also added the SatNOGS id as an alternative name. This could open up the use of the satnogs id's when decoding the satellites.

The only question is, are alternative names always available in the gr-satellite functions ?