### PR TITLE
Create IRIS-C.yml

### DIFF
--- a/python/satyaml/IRIS-C.yml
+++ b/python/satyaml/IRIS-C.yml
@@ -1,0 +1,27 @@
+name: IRIS-C
+norad: 56221
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  1k2 BPSK downlink:
+    frequency: 436.915e+6
+    modulation: BPSK
+    baudrate: 1200
+    framing: AX.25 G3RUH
+    data:
+    - *tlm
+  2k4 BPSK downlink:
+    frequency: 436.915e+6
+    modulation: BPSK
+    baudrate: 2400
+    framing: AX.25 G3RUH
+    data:
+    - *tlm
+  9k6 BPSK downlink:
+    frequency: 436.915e+6
+    modulation: BPSK
+    baudrate: 9600
+    framing: AX.25 G3RUH
+    data:
+    - *tlm


### PR DESCRIPTION
Based on the following observation https://network.satnogs.org/observations/8714848/ also added 1k4 and 2k4

Decode example:

```
-> Packet from 2k4 BPSK downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'BN0CKU' (total 6)
                ssid = Container: 
                    ch = True
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'BN0IRC' (total 6)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = True
        control = 0x03
        pid = 0xF0
    info = b'\x00\x02\x02\x00\x08\x03\xc10\x00\x81\x10\x03\x19-\x0f\x92}\x00\xfe\x02\xdc,\x165\x00\x01\x00\x00WT\x0b\x00\x00\x00\xf0\x03xh\x00\x00\x01Pv\x01^r\\p\x84\x05\xf9\x01\x82\t\x01>\x161\x00\x00\x000\x00\x00\x00e|\xd5\xfd\x01\xec\x1d\x99\xcb\xeb\xd8\x07\xff\xfe\x00\x03\xff\xff\xff\xe7\x00!\xff\xf1\xfc$\x16@hl7\xb3g\x9f\xec\x13\x1ed\r\xc6\xbbo\xe3\xfe\nY\xfb\xb4\x00\x00\x00\x00\x00\x00\x00\x00\x00\x85\x00\x07\x00\x02\x00\x00\x00\x00\x00\x00\x00<\x00\x00\x00\xbd\xb8\x01' (total 141)
```