### PR TITLE
Update MONITOR-2.yml

### DIFF
--- a/python/satyaml/MONITOR-2.yml
+++ b/python/satyaml/MONITOR-2.yml
@@ -1,36 +1,17 @@
 name: MONITOR-2
 alternative_names:
   - RS39S
-norad: 57174
+norad: 57184
 data:
   &tlm Telemetry:
     telemetry: ax25
 transmitters:
-  1k2 FSK downlink:
-    frequency: 435.860e+6
-    modulation: FSK
+  1k2 AFSK downlink:
+    frequency: 435.815e+6
+    modulation: AFSK
     baudrate: 1200
-    framing: USP
-    data:
-    - *tlm
-  2k4 FSK downlink:
-    frequency: 435.860e+6
-    modulation: FSK
-    baudrate: 2400
-    framing: USP
-    data:
-    - *tlm
-  4k8 FSK downlink:
-    frequency: 435.860e+6
-    modulation: FSK
-    baudrate: 4800
-    framing: USP
-    data:
-    - *tlm
-  9k6 FSK downlink:
-    frequency: 435.860e+6
-    modulation: FSK
-    baudrate: 9600
-    framing: USP
+    af_carrier: 1700
+    deviation: 600
+    framing: AX.25
     data:
     - *tlm


### PR DESCRIPTION
Monitor-2 has AFSK and FSK, the FSK part is unknown. So removed the FSK part and added the AFSK

`gr_satellites MONITOR-2.yml --wavfile 7842017.ogg --samp_rate 48e3`

```
-> Packet from 1k2 AFSK downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'CQ' (total 2)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'RS39S' (total 5)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = True
        control = 0x04
        pid = 0x01
    info = b'230711233731;U1BS=8088;U2BS=8000;U3BS=8000;IAB=-64;ISUN=560;TCPU=15;T1AB=1;T2AB=1;T3AB=6;T4AB=6;TRF=-1;fBCK=1F;f1cd=3;f1sp=13;f2cd=0;f2sp=12' (total 140)
```