### PR TITLE
Fix varlen blocks wrong args type for gnuradio-3.10.

### DIFF
--- a/grc/satellites_varlen_packet_framer.block.yml
+++ b/grc/satellites_varlen_packet_framer.block.yml
@@ -15,9 +15,9 @@ parameters:
     default: '12'
 -   id: endianness
     label: Endianness
-    dtype: int
-    default: int(gr.GR_MSB_FIRST)
-    options: [int(gr.GR_MSB_FIRST), int(gr.GR_LSB_FIRST)]
+    dtype: raw
+    default: gr.GR_MSB_FIRST
+    options: [gr.GR_MSB_FIRST, gr.GR_LSB_FIRST]
     option_labels: [MSB, LSB]
 -   id: use_golay
     label: Golay Encoding

--- a/grc/satellites_varlen_packet_tagger.block.yml
+++ b/grc/satellites_varlen_packet_tagger.block.yml
@@ -23,9 +23,9 @@ parameters:
     default: 255*8
 -   id: endianness
     label: Endianness
-    dtype: int
-    default: int(gr.GR_MSB_FIRST)
-    options: [int(gr.GR_MSB_FIRST), int(gr.GR_LSB_FIRST)]
+    dtype: raw
+    default: gr.GR_MSB_FIRST
+    options: [gr.GR_MSB_FIRST, gr.GR_LSB_FIRST]
     option_labels: [MSB, LSB]
 -   id: use_golay
     label: Golay Decoding


### PR DESCRIPTION
Fixes error `Expression <endianness_t.GR_MSB_FIRST: 0> is invalid for type 'int'.` in varlen_packed_tagger, tested with gr-3.10.