### PR TITLE
Add support for ERMINAZ

### DIFF
--- a/docs/source/satyaml.rst
+++ b/docs/source/satyaml.rst
@@ -92,7 +92,7 @@ The modulations allowed in the ``modulation`` field are the following:
 
 * ``FSK subaudio``, for which the :ref:`FSK demodulator` with Subaudio set to
   ``True`` is used
-  
+
 * ``BPSK``. Coherent BPSK, for which the :ref:`BPSK demodulator` with
   Differential and Manchester set to ``False`` is used
 
@@ -112,7 +112,7 @@ The ``AFSK`` modulation also needs the ``deviation`` and ``af_carrier`` fields
 that indicate the AFSK tone frequencies in Hz, as in the AFSK demodulator. Optionally,
 it is possible to indicate the deviation of the FM modulation using the ``fm_deviation``
 field. By default, an FM deviation of 3 kHz is assumed.
-  
+
 The framings allowed in the ``framing`` field are the following:
 
 * ``AX.25``, `AX.25`_ with no scrambling (see :ref:`AX.25 deframer`)
@@ -226,7 +226,7 @@ The framings allowed in the ``framing`` field are the following:
   from TU Berlin
 
 * ``FOSSATSAT``, a custom protocol used by FOSSASAT
-  
+
 * ``AISTECHSAT-2``, a custom CCSDS-like protocol used by AISTECHSAT-2
 
 * ``AALTO-1``, custom framing used by AALTO-1. It uses a
@@ -265,7 +265,9 @@ The framings allowed in the ``framing`` field are the following:
 * ``GEOSCAN``, the custom framing used by GEOSCAN-EDELVEIS.
 
 * ``SPINO``, the custom framing used by the SPINO payload on INSPIRE-Sat7.
-  
+
+* ``QUBIK``, the custom framing used by QUBIK.
+
 Some framings, such as the CCSDS protocols need the additional field
 ``frame size`` to indicate the frame size.
 
@@ -333,7 +335,7 @@ The allowable transport protocols are the following:
 
 * ``KISS KS-1Q``, KISS variant used by KS-1Q, which includes a header before the
   KISS bytes
-  
+
 .. _YAML: https://yaml.org/
 .. _AX.25: http://www.ax25.net/
 .. _FX.25: https://en.wikipedia.org/wiki/FX.25_Forward_Error_Correction

--- a/grc/components/deframers/CMakeLists.txt
+++ b/grc/components/deframers/CMakeLists.txt
@@ -49,6 +49,7 @@ install(FILES
     satellites_ngham_deframer.block.yml
     satellites_nusat_deframer.block.yml
     satellites_ops_sat_deframer.block.yml
+    satellites_qubik_deframer.block.yml
     satellites_reaktor_hello_world_deframer.block.yml
     satellites_sanosat_deframer.block.yml
     satellites_sat_3cat_1_deframer.block.yml

--- a/grc/components/deframers/satellites_qubik_deframer.block.yml
+++ b/grc/components/deframers/satellites_qubik_deframer.block.yml
@@ -1,12 +1,12 @@
-id: satellites_hades_deframer
-label: HADES-D Deframer
+id: satellites_qubik_deframer
+label: QUBIK Deframer
 category: '[Satellites]/Deframers'
 
 parameters:
 -   id: threshold
     label: Syncword threshold
     dtype: int
-    default: 0
+    default: 4
 -   id: options
     label: Command line options
     dtype: string
@@ -23,20 +23,19 @@ outputs:
 
 templates:
     imports: import satellites.components.deframers
-    make: satellites.components.deframers.hades_deframer(syncword_threshold=${threshold}, options=${options})
+    make: satellites.components.deframers.qubik_deframer(syncword_threshold=${threshold}, options=${options})
 
 documentation: |-
-    Deframes HADES-D packets
+    Deframes QUBIK packets
 
-    See the following documents for the specifications
-    https://www.amsat-ea.org/app/download/13595424/AMSAT+EA+-+Descripci%C3%B3n+de+transmisiones+de+HADES-D.pdf
-    https://www.amsat-ea.org/app/download/13595777/AMSAT+EA+-+HADES-D+Transmissions+description.pdf
+    QUBIK packets use a custom 32-bit syncword, CCSDS Reed-Solomon, CCSDS
+    scrambling (unusually applied before Reed-Solomon encoding), and a CRC-32C.
 
     Input:
-        A stream of soft symbols containing HADES-D packets
+        A stream of soft symbols containing QUBIK packets
 
     Output:
-        PDUs with the deframed HADES-D packets
+        PDUs with the deframed QUBIK packets
 
     Parameters:
         Syncword threshold: number of bit errors to allow in syncword detection

--- a/python/components/deframers/CMakeLists.txt
+++ b/python/components/deframers/CMakeLists.txt
@@ -60,6 +60,7 @@ GR_PYTHON_INSTALL(
     ngham_deframer.py
     nusat_deframer.py
     ops_sat_deframer.py
+    qubik_deframer.py
     reaktor_hello_world_deframer.py
     sanosat_deframer.py
     sat_3cat_1_deframer.py

--- a/python/components/deframers/__init__.py
+++ b/python/components/deframers/__init__.py
@@ -46,6 +46,7 @@ from .mobitex_deframer import mobitex_deframer
 from .ngham_deframer import ngham_deframer
 from .nusat_deframer import nusat_deframer
 from .ops_sat_deframer import ops_sat_deframer
+from .qubik_deframer import qubik_deframer
 from .reaktor_hello_world_deframer import reaktor_hello_world_deframer
 from .sanosat_deframer import sanosat_deframer
 from .sat_3cat_1_deframer import sat_3cat_1_deframer

--- a/python/components/deframers/qubik_deframer.py
+++ b/python/components/deframers/qubik_deframer.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Daniel Estevez <daniel@destevez.net>
+#
+# This file is part of gr-satellites
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gnuradio import gr, blocks, digital
+
+from ... import decode_rs
+from ...crcs import crc32c, crc16_ccitt_false
+from ...hier.ccsds_descrambler import ccsds_descrambler
+from ...hier.sync_to_pdu_packed import sync_to_pdu_packed
+from ...utils.options_block import options_block
+
+
+# 0x3C674952
+_syncword = '00111100011001110100100101010010'
+
+
+class qubik_deframer(gr.hier_block2, options_block):
+    """
+    Hierarchical block to deframe QUBIK custom frames
+
+    QUBIK frames use a custom 32-bit syncword, CCSDS Reed-Solomon,
+    CCSDS scrambling (unusually applied before Reed-Solomon encoding),
+    and a CRC-32C and CRC-16-CCITT-FALSE.
+
+    https://gitlab.com/amsat-dl/erminaz/erminaz-comms-sw/-/blob/master/test/flowgraphs/qubik_transceiver.grc?ref_type=heads
+    https://gitlab.com/librespacefoundation/satnogs/gr-satnogs/-/blob/master/lib/ieee802_15_4_variant_decoder.cc?ref_type=heads
+
+    The input is a float stream of soft symbols. The output are PDUs
+    with frames.
+
+    Args:
+        syncword_threshold: number of bit errors allowed in syncword (int)
+        options: Options from argparse
+    """
+    def __init__(self, syncword_threshold=None, options=None):
+        gr.hier_block2.__init__(
+            self,
+            'qubik_deframer',
+            gr.io_signature(1, 1, gr.sizeof_float),
+            gr.io_signature(0, 0, 0))
+        options_block.__init__(self, options)
+
+        self.message_port_register_hier_out('out')
+
+        if syncword_threshold is None:
+            syncword_threshold = self.options.syncword_threshold
+
+        self.slicer = digital.binary_slicer_fb()
+        self.deframer = sync_to_pdu_packed(
+            # +32 because of RS parity check bytes
+            # +4 because of CRC-32C
+            packlen=128+32+4, sync=_syncword,
+            threshold=syncword_threshold)
+        self.rs = decode_rs(False, 1)
+        self.pdu2tag = blocks.pdu_to_tagged_stream(blocks.byte_t, 'packet_len')
+        self.unpack = blocks.unpack_k_bits_bb(8)
+        self.multiply_length = blocks.tagged_stream_multiply_length(
+            gr.sizeof_char, 'packet_len', 8.0)
+        self.tag2pdu = blocks.tagged_stream_to_pdu(blocks.byte_t, 'packet_len')
+        self.descrambler = ccsds_descrambler()
+        self.crc = crc32c()
+        self.crc16 = crc16_ccitt_false()
+
+        self.connect(self, self.slicer, self.deframer)
+        self.msg_connect((self.deframer, 'out'), (self.rs, 'in'))
+        self.msg_connect((self.rs, 'out'), (self.pdu2tag, 'pdus'))
+        self.connect(self.pdu2tag, self.unpack, self.multiply_length,
+                     self.tag2pdu)
+        self.msg_connect((self.tag2pdu, 'pdus'), (self.descrambler, 'in'))
+        self.msg_connect((self.descrambler, 'out'), (self.crc, 'in'))
+        self.msg_connect((self.crc, 'ok'), (self.crc16, 'in'))
+        self.msg_connect((self.crc16, 'ok'), (self, 'out'))
+
+    _default_sync_threshold = 4
+
+    @classmethod
+    def add_options(cls, parser):
+        """
+        Adds QUBIK deframer specific options to the argparse parser
+        """
+        parser.add_argument(
+            '--syncword_threshold', type=int,
+            default=cls._default_sync_threshold,
+            help='Syncword bit errors [default=%(default)r]')

--- a/python/core/gr_satellites_flowgraph.py
+++ b/python/core/gr_satellites_flowgraph.py
@@ -470,6 +470,7 @@ class gr_satellites_flowgraph(gr.hier_block2):
             deframers.reaktor_hello_world_deframer,
             syncword='light-1'),
         'SPINO': deframers.spino_deframer,
+        'QUBIK': deframers.qubik_deframer,
         }
     _transport_hooks = {
         'KISS': transports.kiss_transport,

--- a/python/crcs.py
+++ b/python/crcs.py
@@ -34,3 +34,8 @@ def crc16_ccitt_zero(swap_endianness=False, discard_crc=True):
 def crc16_cc11xx(discard_crc=True):
     return crc_check(16, 0x8005, 0xFFFF, 0x0, False, False,
                      False, discard_crc)
+
+
+def crc32c(discard_crc=True):
+    return crc_check(32, 0x1EDC6F41, 0xFFFFFFFF, 0xFFFFFFFF,
+                     True, True, False, discard_crc)

--- a/python/satyaml/ERMINAZ-1U.yml
+++ b/python/satyaml/ERMINAZ-1U.yml
@@ -1,0 +1,14 @@
+name: ERMINAZ-1U
+norad: 99999
+data:
+  &tlm Telemetry:
+    telemetry: erminaz
+transmitters:
+  9k6 FSK downlink:
+    frequency: 435.775e+6
+    modulation: FSK
+    baudrate: 9600
+    deviation: 3000
+    framing: QUBIK
+    data:
+    - *tlm

--- a/python/satyaml/satyaml.py
+++ b/python/satyaml/satyaml.py
@@ -42,7 +42,7 @@ class SatYAML:
         'YUSAT', 'AX5043', 'USP', 'AO-40 FEC CRC-16-ARC',
         'AO-40 FEC CRC-16-ARC short', 'DIY-1', 'BINAR-1', 'Endurosat',
         'SanoSat', 'FORESAIL-1', 'HSU-SAT1', 'GEOSCAN', 'Light-1',
-        'SPINO',
+        'SPINO', 'QUBIK',
         ]
     transports = [
         'KISS', 'KISS no control byte', 'KISS KS-1Q',

--- a/python/telemetry/CMakeLists.txt
+++ b/python/telemetry/CMakeLists.txt
@@ -50,6 +50,7 @@ GR_PYTHON_INSTALL(
     delfic3.py
     delfipq.py
     dstar_one.py
+    erminaz.py
     eseo.py
     fossasat.py
     fossasat_1b.py

--- a/python/telemetry/__init__.py
+++ b/python/telemetry/__init__.py
@@ -33,6 +33,7 @@ from .cute_70cm import cute_70cm
 from .delfic3 import delfic3
 from .delfipq import delfipq
 from .dstar_one import dstar_one
+from .erminaz import erminaz
 from .eseo import eseo
 from .floripasat import floripasat
 from .fossasat_1b import fossasat_1b

--- a/python/telemetry/erminaz.py
+++ b/python/telemetry/erminaz.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2024 Daniel Estevez <daniel@destevez.net>
+#
+# This file is part of gr-satellites
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from construct import *
+
+
+TMPrimaryHeader = BitStruct(
+    'transfer_frame_version_number' / BitsInteger(2),
+    'spacecraft_id' / BitsInteger(10),
+    'virtual_channel_id' / BitsInteger(3),
+    'ocf_flag' / Flag,
+    'master_channel_frame_count' / BitsInteger(8),
+    'virtual_channel_frame_count' / BitsInteger(8),
+    'secondary_header_flag' / Flag,
+    'synch_flag' / Flag,
+    'packet_order_flag' / Flag,
+    'segment_length_id' / BitsInteger(2),
+    'first_header_pointer' / BitsInteger(11)
+)
+
+
+erminaz = Struct(
+    'primary_header' / TMPrimaryHeader,
+    'data_field' / HexDump(GreedyBytes)
+)


### PR DESCRIPTION
This adds a QUBIK deframer, a SatYAML file for ERMINAZ, and a basic telemetry definition for ERMINAZ that only parser the CCSDS TM Primary Header.