### PR TITLE
Add deviation to MCUBED-2

### DIFF
--- a/python/satyaml/MCUBED-2.yml
+++ b/python/satyaml/MCUBED-2.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.480e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
Observation [9702028](https://network.satnogs.org/observations/9702028/)
dd bs=$((4*57600)) if=iq_9702028_57600.raw of=mcubed2_cut.raw skip=357 count=1
gr_satellites mcubed-2 --iq --rawint16 mcubed2_cut.raw --samp_rate 57600 --dump_path dump --deviation 2400 --disable_dc_block
![mcubed2_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/0164cc2e-93d8-43d9-98a7-e4321a06b496)
