### PR TITLE
Add deviation to UPMSat_2

### DIFF
--- a/python/satyaml/UPMSat_2.yml
+++ b/python/satyaml/UPMSat_2.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.405e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 600
     framing: AX.25
     data:
     - *tlm


### PR DESCRIPTION
UPMSat 2 (46276)
Observation [9733931](https://network.satnogs.org/observations/9733931/)
dd bs=$((4*48000)) if=iq_9733931_48000.raw of=upmsat2_cut.raw skip=326 count=2
gr_satellites 'upmsat 2' --iq --rawint16 upmsat2_cut.raw --samp_rate 48000 --dump_path dump --deviation 600 --disable_dc_block
![upmsat2_dev600](https://github.com/daniestevez/gr-satellites/assets/5262110/4caeb6b1-de5f-42b4-bc19-4ff31d55bf0a)
