### PR TITLE
Add deviation to TIGRISAT

### DIFF
--- a/python/satyaml/TIGRISAT.yml
+++ b/python/satyaml/TIGRISAT.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.000e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
TIGRISAT (40043)
Observation [9691434](https://network.satnogs.org/observations/9691434/)
dd bs=$((4*57600)) if=iq_9691434_57600.raw of=tigrisat_cut.raw skip=510 count=1
gr_satellites tigrisat --iq --rawint16 tigrisat_cut.raw --samp_rate 57600 --dump_path dump --deviation 2400 --disable_dc_block
![tigrisat_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/0fa6ad48-ba09-43b2-8495-7871ff9be57a)
