### PR TITLE
Add deviation to NANOFF-A

### DIFF
--- a/python/satyaml/NANOFF-A.yml
+++ b/python/satyaml/NANOFF-A.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.950e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex-NX
     data:
     - *tlm
@@ -15,6 +16,7 @@ transmitters:
     frequency: 435.950e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 1200
     framing: Mobitex-NX
     data:
     - *tlm


### PR DESCRIPTION
NanoFF A (58810)
Observation [9741697](https://network.satnogs.org/observations/9741697/)
dd bs=$((4*48000)) if=iq_9741697_48000.raw of=nanoffa_cut.raw skip=341 count=3
gr_satellites NANOFF-A_48.yml --iq --rawint16 nanoffa_cut.raw --samp_rate 48000 --dump_path dump --deviation 1200 --disable_dc_block
4800 baud = 1200 deviation
![nanoffa_dev1200_b4800](https://github.com/daniestevez/gr-satellites/assets/5262110/e8b04a7c-428e-432e-b011-6431dfb317c4)

dd bs=$((4*48000)) if=iq_9741697_48000.raw of=nanoffa_cut.raw skip=343 count=4
gr_satellites NANOFF-A_96.yml --iq --rawint16 nanoffa_cut.raw --samp_rate 48000 --dump_path dump --deviation 1200 --disable_dc_block
9600 baud = 1200 deviation
![nanoffa_dev1200_b9600](https://github.com/daniestevez/gr-satellites/assets/5262110/ea8f2325-ba56-4898-99da-b490e3ea499f)
