### PR TITLE
Add deviation to NANOFF-B

### DIFF
--- a/python/satyaml/NANOFF-B.yml
+++ b/python/satyaml/NANOFF-B.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.950e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex-NX
     data:
     - *tlm
@@ -15,6 +16,7 @@ transmitters:
     frequency: 435.950e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 1200
     framing: Mobitex-NX
     data:
     - *tlm


### PR DESCRIPTION
NanoFF B (58755)
Observation [9741703](https://network.satnogs.org/observations/9741703/)
dd bs=$((4*48000)) if=iq_9741703_48000.raw of=nanoffb_cut.raw skip=371 count=3
gr_satellites NANOFF-B_48.yml --iq --rawint16 nanoffb_cut.raw --samp_rate 48000 --deviation 1200 --dump_path dump --disable_dc_block
4800 baud = 1200 deviation

![nanoffb_dev1200_b4800](https://github.com/daniestevez/gr-satellites/assets/5262110/aa9c5ded-949c-40aa-b5c3-cd074d6c9077)

Observation [9741705](https://network.satnogs.org/observations/9741705/)
dd bs=$((4*48000)) if=iq_9741705_48000.raw of=nanoffb_cut.raw skip=90 count=110
gr_satellites NANOFF-B_96.yml --iq --rawint16 nanoffb_cut.raw --samp_rate 48000 --deviation 1200 --dump_path dump --disable_dc_block
very weak, but looks pretty much like NannoFF A at 9k6, preamble looks almost the same amplitude as the syncword.
9600 baud = 1200 deviation

![nanoffb_dev1200_b9600](https://github.com/daniestevez/gr-satellites/assets/5262110/69dcc4d6-e7f7-4fab-8de4-ace68bfc2759)
