### PR TITLE
Add deviation to ENSO

### DIFF
--- a/python/satyaml/ENSO.yml
+++ b/python/satyaml/ENSO.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 436.500e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: AX.25
     data:
     - *tlm


### PR DESCRIPTION
ENSO (58470)
Observation [9268176](https://network.satnogs.org/observations/9268176/)
dd bs=$((4*48000)) if=iq_9268176_48000.raw of=enso_cut.raw skip=505 count=5
gr_satellites enso --iq --rawint16 enso_cut.raw --samp_rate 48e3 --deviation 600 --dump_path dump --disable_dc_block
peaks at 0.75 and -1.25
![enso_dev600](https://github.com/daniestevez/gr-satellites/assets/5262110/a4d87206-ee77-4162-9743-2515b9f80ac6)
