### PR TITLE
Add deviation to DEKART

### DIFF
--- a/python/satyaml/DEKART.yml
+++ b/python/satyaml/DEKART.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.000e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex
     data:
     - *tlm


### PR DESCRIPTION
DEKART (46493)
Observation [8960133](https://network.satnogs.org/observations/8960133/)
dd bs=$((4*48000)) if=iq_8960133_48000.raw of=dekart_cut.raw skip=110 count=5
gr_satellites dekart --iq --rawint16 dekart_cut.raw --samp_rate 48e3 --deviation 1200 --dump_path dump --disable_dc_block
![dekart_dev1200](https://github.com/daniestevez/gr-satellites/assets/5262110/123256ee-60a8-4d01-b75d-6b8140458741)
