### PR TITLE
Add deviation to OrbiCraft-Zorkiy

### DIFF
--- a/python/satyaml/OrbiCraft-Zorkiy.yml
+++ b/python/satyaml/OrbiCraft-Zorkiy.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 437.850e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: USP
     data:
     - *tlm
@@ -22,6 +23,7 @@ transmitters:
     frequency: 437.850e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
OrbiCraft-Zorkiy (47960)

I have no observations/recordings of the 1200 and 9600 baud.

Observation [8977225](https://network.satnogs.org/observations/8977225/)
dd bs=$((4*57600)) if=iq_8977225_57600.raw of=zorkiy_cut.raw skip=80 count=10
gr_satellites OrbiCraft-Zorkiy_24.yml --iq --rawint16 zorkiy_cut.raw --samp_rate 57600 --deviation 600 --dump_path dump --disable_dc_block
2400 baud = 600 deviation

![orb_zorkiy_dev600_b2400](https://github.com/daniestevez/gr-satellites/assets/5262110/34d8d2af-81cc-470c-be9a-aefe59dee48e)

Observation [9034717](https://network.satnogs.org/observations/9034717/)
dd bs=$((4*57600)) if=iq_9034717_57600.raw of=zorkiy_cut.raw skip=54 count=3
gr_satellites OrbiCraft-Zorkiy_48.yml --iq --rawint16 zorkiy_cut.raw --samp_rate 57600 --deviation 1200 --dump_path dump --disable_dc_block
4800 baud = 1200 deviation

![orb_zorkiy_dev1200_b4800](https://github.com/daniestevez/gr-satellites/assets/5262110/f79530c8-b654-4e5a-8176-a7e89747dd74)
