### PR TITLE
Update deviation on EIRSAT-1

### DIFF
--- a/python/satyaml/EIRSAT-1.yml
+++ b/python/satyaml/EIRSAT-1.yml
@@ -13,7 +13,7 @@ transmitters:
     RS basis: dual 
     RS interleaving: 4
     convolutional: CCSDS uninverted
-    deviation: -2400
+    deviation: -3500
     data:
     - *tlm
   9k6 GMSK downlink:
@@ -24,6 +24,6 @@ transmitters:
     frame size: 892
     RS basis: dual 
     RS interleaving: 4
-    deviation: -2400
+    deviation: -3500
     data:
     - *tlm


### PR DESCRIPTION
EIRSAT-1 (58472)
Observation [9494233](https://network.satnogs.org/observations/9494233/)
dd bs=$((4*57600)) if=iq_9494233_57600.raw of=eirsat1_cut.raw skip=366 count=5
gr_satellites EIRSAT-1.yml --iq --rawint16 eirsat1_cut.raw --samp_rate 57.6e3 --dump_path dump --disable_dc_block --deviation -3500
run with old deviation removed from satyaml, result 1.15 to -0.85 
![eirsat1_dev3500](https://github.com/daniestevez/gr-satellites/assets/5262110/c7a540ea-e0ea-4613-8b1c-773d87f69f40)

Here's with the old -2400 deviation for reference:
![eirsat1_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/79d7ddde-9c67-45a4-9cf1-a3a978f761e4)
