### PR TITLE
Add deviation to GRBAlpha

### DIFF
--- a/python/satyaml/GRBAlpha.yml
+++ b/python/satyaml/GRBAlpha.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.025e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
GRBAlpha (47959)
Observation [9774544](https://network.satnogs.org/observations/9774544/)
dd bs=$((4*57600)) if=iq_9774544_57600.raw of=grbalpha_cut.raw skip=359 count=1
gr_satellites grbalpha --iq --rawint16 grbalpha_cut.raw --samp_rate 57600 --dump_path dump --deviation 2400 --disable_dc_block
![grbalpha_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/aa65d4d8-8289-4d7d-9ee9-80393a80fbd8)
