### PR TITLE
Add deviation to SONATE-2, update norad

### DIFF
--- a/python/satyaml/SONATE-2.yml
+++ b/python/satyaml/SONATE-2.yml
@@ -1,5 +1,5 @@
 name: SONATE-2
-norad: 98959
+norad: 59112
 data:
   &tlm Telemetry:
     telemetry: ax25
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.025e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
SONATE-2 (59112)
Observation [9719955](https://network.satnogs.org/observations/9719955/)
dd bs=$((4*57600)) if=iq_9719955_57600.raw of=sonate2_cut.raw skip=362 count=2
gr_satellites sonate-2 --iq --rawint16 sonate2_cut.raw --samp_rate 57.6e3 --dump_path dump --disable_dc_block --deviation 2400
+1.2 to -0.85 approx
![sonate2_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/a8444361-9d72-4b7c-b601-bb22fab5c1b9)
