### PR TITLE
Fix USP AX25 crop block issue in Gnuradio.

### DIFF
--- a/grc/usp/satellites_usp_ax25_crop.block.yml
+++ b/grc/usp/satellites_usp_ax25_crop.block.yml
@@ -1,4 +1,4 @@
-id: satellites_usp_ax.25_crop
+id: satellites_usp_ax25_crop
 label: USP AX.25 Crop
 category: '[Satellites]/USP'
 


### PR DESCRIPTION
Hello, GNU Radio can`t use blocks with dots in name, I get error when using it in gnuradio-companion. PR fixes this.