### PR TITLE
Add deviation to Lucky-7

### DIFF
--- a/python/satyaml/Lucky-7.yml
+++ b/python/satyaml/Lucky-7.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 437.525e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 4800
     framing: Lucky-7
     data:
     - *tlm


### PR DESCRIPTION
Lucky-7 (44406)
Observation [9667997](https://network.satnogs.org/observations/9667997/)
dd bs=$((4*48000)) if=iq_9667997_48000.raw of=lucky7_cut.raw skip=372 count=1
gr_satellites lucky-7 --iq --rawint16 lucky7_cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 4800
![lucky7_dev4800](https://github.com/daniestevez/gr-satellites/assets/5262110/23fd2cc3-599c-4af7-89eb-741798820048)
Pretty spot on +/- 1

I also looked at the deviation default at 5000, it is slightly lower at +/- 0.95 
![lucky7_dev5000](https://github.com/daniestevez/gr-satellites/assets/5262110/c463060a-2fd6-4d8b-9cd1-222393333fe3)
