### PR TITLE
Add deviation to CubeBel-2

### DIFF
--- a/python/satyaml/CubeBel-2.yml
+++ b/python/satyaml/CubeBel-2.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 436.990e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
CUBEBEL-2
Observation [9645147](https://network.satnogs.org/observations/9645147/)
dd bs=$((4*57600)) if=iq_9645147_57600.raw of=cubebel2_cut.raw skip=462 count=2
gr_satellites cubebel-2 --iq --rawint16 cubebel2_cut.raw --samp_rate 57.6e3 --dump_path dump --disable_dc_block --deviation 2400
0.85 to -1.15 at deviation 2400
![cubebel2_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/0364531d-5fae-44c5-b055-87d327770cf4)
