### PR TITLE
Add deviation to JAISAT-1

### DIFF
--- a/python/satyaml/JAISAT-1.yml
+++ b/python/satyaml/JAISAT-1.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.700e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex
     data:
     - *tlm


### PR DESCRIPTION
JAISAT-1 (44419)
Observation [9638732](https://network.satnogs.org/observations/9638732/)
dd bs=$((4*48000)) if=iq_9638732_48000.raw of=jaisat1_cut.raw skip=264 count=2
gr_satellites jaisat-1 --iq --rawint16 jaisat1_cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 1200
![jaisat1_dev1200](https://github.com/daniestevez/gr-satellites/assets/5262110/36c2b949-653e-448a-83f2-0f112e8e1aa6)
