### PR TITLE
Add deviation to BEESAT-9

### DIFF
--- a/python/satyaml/BEESAT-9.yml
+++ b/python/satyaml/BEESAT-9.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.950e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1800
     framing: Mobitex-NX
     data:
     - *tlm


### PR DESCRIPTION
BEESAT-9 (44412)
Observation [9627570](https://network.satnogs.org/observations/9627570/)
dd bs=$((4*48000)) if=iq_9627570_48000.raw of=beesat9_cut.raw skip=245 count=3
gr_satellites beesat-9 --iq --rawint16 beesat9_cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 1800
1800 is another oddball, not a really a round value. in the same vincinity as EIRSAT at a baud/dev of ~2.7
![beesat9_dev1800](https://github.com/daniestevez/gr-satellites/assets/5262110/28383d2b-ac87-41aa-87a2-2909947c16fc)
pretty unstable transmitter, looks like it is starting cold and the reference is heated by the tx