### PR TITLE
Add deviation to D-Star One LightSat

### DIFF
--- a/python/satyaml/D-STAR_ONE_LightSat.yml
+++ b/python/satyaml/D-STAR_ONE_LightSat.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.700e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex
     data:
     - *tlm


### PR DESCRIPTION
D-STAR ONE LIGHTSAT (44393)
Observation [9054340](https://network.satnogs.org/observations/9054340/)
dd bs=$((4*48000)) if=iq_9054340_48000.raw of=dsonel_cut.raw skip=95 count=2
gr_satellites 'D-STAR ONE LightSat' --iq --rawint16 dsonel_cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
![dsonel_dev1200](https://github.com/daniestevez/gr-satellites/assets/5262110/941d4dd3-ad57-4ad8-b019-4fe387b52057)
