### PR TITLE
Update norad in KS-1Q

### DIFF
--- a/python/satyaml/KS-1Q.yml
+++ b/python/satyaml/KS-1Q.yml
@@ -1,5 +1,5 @@
 name: KS-1Q
-norad: 41845
+norad: 41847
 data:
   &tlm Telemetry:
     telemetry: csp


### PR DESCRIPTION
Old IS is decayed: http://celestrak.org/satcat/table-satcat.php?CATNR=41845&PAYLOAD=1&MAX=500

http://celestrak.org/satcat/table-satcat.php?CATNR=41847&PAYLOAD=1&MAX=500
https://db.satnogs.org/satellite/WMGA-3000-1529-8035-2634
another name but beacon frequency seems to match https://www.n2yo.com/satellite/?s=41847#results