### PR TITLE
Add deviation to BISONSAT

### DIFF
--- a/python/satyaml/BISONSAT.yml
+++ b/python/satyaml/BISONSAT.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 437.375e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2700
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
BISONSAT (40974)
Observation [9677377](https://network.satnogs.org/observations/9677377/)
dd bs=$((4*57600)) if=iq_9677377_57600.raw of=bisonsat_cut.raw skip=322 count=1
gr_satellites bisonsat --iq --rawint16 bisonsat_cut.raw --samp_rate 57600 --deviation 2700 --dump_path dump --disable_dc_block
![bisonsat_dev2700](https://github.com/daniestevez/gr-satellites/assets/5262110/48c5c637-c5fb-4e61-aaa9-e4151e864da2)
a bit odd deviation