### PR TITLE
Add deviation to BDSAT-2

### DIFF
--- a/python/satyaml/BDSat-2.yml
+++ b/python/satyaml/BDSat-2.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 436.025e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
BDSAT-2 (55098)
Observation [9299905](https://network.satnogs.org/observations/9299905/)
dd bs=$((4*57600)) if=iq_9299905_57600.raw of=bdsat2_cut.raw skip=335 count=10
gr_satellites bdsat-2 --iq --rawint16 bdsat2_cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3000
![bdsat2_dev3000](https://github.com/daniestevez/gr-satellites/assets/5262110/ac5322de-5ce1-4161-9271-0e792c744341)
