### PR TITLE
Add deviation to VZLUSAT-2

### DIFF
--- a/python/satyaml/VZLUSAT-2.yml
+++ b/python/satyaml/VZLUSAT-2.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 437.325e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
VZLUSAT-2 (51085)
Observation [9043955](https://network.satnogs.org/observations/9043955/)
dd bs=$((4*57600)) if=iq_9043955_48000.raw of=vzlusat2_cut.raw skip=90 count=5
gr_satellites VZLUSAT-2_48.yml --iq --rawint16 vzlusat2_cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1600
4k8 downlink, deviation 1600, new "round" one 4800/1600=3
![vzlusat2_dev1600](https://github.com/daniestevez/gr-satellites/assets/5262110/cd1f19f4-a6cd-459c-88af-c34adce0ec12)
