### PR TITLE
Add deviation to UWE-4

### DIFF
--- a/python/satyaml/UWE-4.yml
+++ b/python/satyaml/UWE-4.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 435.600e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 5400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
UWE-4 (43880)
Observation [8982372](https://network.satnogs.org/observations/8982372/)
dd bs=$((4*57600)) if=iq_8982372_57600.raw of=uwe4_cut.raw skip=74 count=2
gr_satellites uwe-4 --iq --rawint16 uwe4_cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 5400
![uwe4_dev5400](https://github.com/daniestevez/gr-satellites/assets/5262110/23281216-bf5f-41ae-803c-39fcc841d699)
