### PR TITLE
Add 9k6 and deviation to ENSO

### DIFF
--- a/python/satyaml/ENSO.yml
+++ b/python/satyaml/ENSO.yml
@@ -14,3 +14,11 @@ transmitters:
     framing: AX.25
     data:
     - *tlm
+  9k6 FSK downlink:
+    frequency: 436.500e+6
+    modulation: FSK
+    baudrate: 9600
+    deviation: 2400
+    framing: AX.25
+    data:
+    - *tlm


### PR DESCRIPTION
58470 - ENSO
Observation [9819762](https://network.satnogs.org/observations/9819762/)
dd bs=$((4*48000)) if=iq_9819762_48000.wav of=enso_cut.raw skip=100 count=2
gr_satellites ENSO_96.yml --iq --rawint16 enso_cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 2400
![enso_9k6_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/3b24c2b6-b7d8-4466-be85-9ba0bf4ed52a)

Thanks Jan @janvgils for the recording.
