### PR TITLE
Add deviation to UmKA-1

### DIFF
--- a/python/satyaml/UmKA-1.yml
+++ b/python/satyaml/UmKA-1.yml
@@ -22,6 +22,7 @@ transmitters:
     frequency: 437.625e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm
@@ -29,6 +30,7 @@ transmitters:
     frequency: 437.625e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: USP
     data:
     - *tlm
@@ -50,6 +52,7 @@ transmitters:
     frequency: 437.625e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: AX.25 G3RUH
     data:
     - *tlm
@@ -57,6 +60,7 @@ transmitters:
     frequency: 437.625e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
UMKA-1 (57172)

Observation [8935590](https://network.satnogs.org/observations/8935590/)
4k8 FSK USP downlink
dd bs=$((4*48000)) if=iq_8935590_48000.raw of=umka1_cut.raw skip=102 count=2
gr_satellites UmKA-1_48.yml --iq --rawint16 umka1_cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 1200
![umka1_48_dev1200](https://github.com/daniestevez/gr-satellites/assets/5262110/0a964f67-d409-4bb4-bd74-320911a0140c)

Observation [8908818](https://network.satnogs.org/observations/8908818/)
9k6 FSK USP downlink
dd bs=$((4*48000)) if=iq_8908818_48000.raw of=umka1_cut.raw skip=96 count=2
gr_satellites UmKA-1_96.yml --iq --rawint16 umka1_cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 2400
![umka1_96_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/8d729b96-dd09-4127-86fb-edf03549eabf)

I have no IQ recordings of 1k2 and 2k4