### PR TITLE
Add deviation to Suomi_100

### DIFF
--- a/python/satyaml/Suomi_100.yml
+++ b/python/satyaml/Suomi_100.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.775e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
Suomi 100 (43804)
Observation [9024954](https://network.satnogs.org/observations/9024954/)
dd bs=$((4*57600)) if=iq_9024954_57600.raw of=cut.raw skip=101 count=1
gr_satellites "Suomi 100" --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![suomi100_dev2400](https://github.com/daniestevez/gr-satellites/assets/5262110/7236166d-41c9-4e8b-bf0e-83ccf143ce82)
