### PR TITLE
Add deviation to STRATOSAT-TK1

### DIFF
--- a/python/satyaml/STRATOSAT-TK1.yml
+++ b/python/satyaml/STRATOSAT-TK1.yml
@@ -10,6 +10,7 @@ transmitters:
      frequency: 435.870e+6
      modulation: FSK
      baudrate: 9600
+     deviation: 4800
      framing: GEOSCAN
      data:
      - *tlm


### PR DESCRIPTION
StratoSat TK-1 (57167)
Observation [9547979](https://network.satnogs.org/observations/9547979/)
dd bs=$((4*57600)) if=iq_9547979_57600.raw of=cut.raw skip=49 count=1
gr_satellites "StratoSat-TK1" --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 4800
![stratosattk1_dev4800](https://github.com/daniestevez/gr-satellites/assets/5262110/013b808c-2b90-4239-9c1e-4fc414703e7e)
