### PR TITLE
Add deviation to SUCHAI-2

### DIFF
--- a/python/satyaml/SUCHAI-2.yml
+++ b/python/satyaml/SUCHAI-2.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 437.230e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
SUCHAI2 (52192)
Observation [9841380](https://network.satnogs.org/observations/9841380/)
dd bs=$((4*48000)) if=iq_9841380_48000.raw of=cut.raw skip=233 count=1
gr_satellites SUCHAI-2.yml --iq --rawint16 cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 1600
4k8 FSK downlink
![suchai2_dev1600](https://github.com/user-attachments/assets/4a4cdc52-27da-482e-8f00-fb28be4b6b67)
