### PR TITLE
Add deviation to SUCHAI-3

### DIFF
--- a/python/satyaml/SUCHAI-3.yml
+++ b/python/satyaml/SUCHAI-3.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 437.250e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
SUCHAI3 (52191) reentered
Observation [9023379](https://network.satnogs.org/observations/9023379/)
dd bs=$((4*48000)) if=iq_9023379_48000.raw of=cut.raw skip=84 count=3
gr_satellites SUCHAI-3.yml --iq --rawint16 cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 1600
4k8 FSK downlink
![suchai3_dev1600](https://github.com/user-attachments/assets/09ac6c99-c494-47cb-a264-755d82bcecd7)
