### PR TITLE
Add deviation to TTU-100

### DIFF
--- a/python/satyaml/TTU-100.yml
+++ b/python/satyaml/TTU-100.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 435.450e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
TTU-100 (46312)
Observation [9841235](https://network.satnogs.org/observations/9841235/)
dd bs=$((4*48000)) if=iq_9841235_48000.raw of=cut.raw skip=254 count=1
gr_satellites ttu-100 --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 3000
![ttu100_dev3000](https://github.com/user-attachments/assets/21520363-beac-417c-b7c7-fc13bed30ac3)
plot with histogram, unfortunately I haven't figured out how to share x-axis between the two to only show histogram with the current zoom of the plot, so the hist is for one second and includes all the noise before/after the frame.