### PR TITLE
Add deviation to SOMP_2b

### DIFF
--- a/python/satyaml/SOMP_2b.yml
+++ b/python/satyaml/SOMP_2b.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.600e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2700
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
SOMP 2b (47445)
Observation [8948188](https://network.satnogs.org/observations/8948188/)
dd bs=$((4*57600)) if=iq_8948188_57600.raw of=cut.raw skip=95 count=1
gr_satellites 'somp 2b' --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2700
![somp2b_dev2700](https://github.com/user-attachments/assets/addebb2d-301e-4994-b33a-2156aa24281f)
