### PR TITLE
Add deviation to SNUGLITE

### DIFF
--- a/python/satyaml/SNUGLITE.yml
+++ b/python/satyaml/SNUGLITE.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 437.275e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
SNUGLITE (43784)
Observation [8950479](https://network.satnogs.org/observations/8950479/)
dd bs=$((4*57600)) if=iq_8950479_57600.raw of=cut.raw skip=73 count=1
gr_satellites snuglite --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![snuglite_dev2400](https://github.com/user-attachments/assets/5a1df535-ef36-468b-8347-53c8a56c8c13)
