### PR TITLE
Add deviation to Sharjahsat-1

### DIFF
--- a/python/satyaml/Sharjahsat-1.yml
+++ b/python/satyaml/Sharjahsat-1.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.325e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
Sharjahsat-1 (55104)
Observation [8980351](https://network.satnogs.org/observations/8980351/)
dd bs=$((4*57600)) if=iq_8980351_57600.raw of=cut.raw skip=131 count=2
gr_satellites sharjahsat-1 --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3000
![sharjahsat1_dev3000](https://github.com/user-attachments/assets/de626dcb-5804-47e1-946b-8804b6896256)
