### PR TITLE
Add deviation to POLYITAN-1

### DIFF
--- a/python/satyaml/POLYITAN-1.yml
+++ b/python/satyaml/POLYITAN-1.yml
@@ -17,6 +17,7 @@ transmitters:
     frequency: 437.676e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
POLYITAN-1 (40042)
Observation [9045285](https://network.satnogs.org/observations/9045285/)
dd bs=$((4*57600)) if=iq_9045285_57600.raw of=cut.raw skip=103 count=1
gr_satellites polyitan-1_96.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3000
![polyitan1_dev3000](https://github.com/user-attachments/assets/74b32fff-1efb-429b-8800-e7d3a443ee0c)
