### PR TITLE
Add deviation to PEARL-1H

### DIFF
--- a/python/satyaml/PEARL-1H.yml
+++ b/python/satyaml/PEARL-1H.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.390e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
PEARL-1H (58265)
Observation [9268013](https://network.satnogs.org/observations/9268013/)
dd bs=$((4*57600)) if=iq_9268013_57600.raw of=cut.raw skip=260 count=1
gr_satellites pearl-1h --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![pearl1h_dev2400](https://github.com/user-attachments/assets/d490ee94-3873-4025-984d-e54ae81b13a5)
