### PR TITLE
Add deviation to NORBI

### DIFF
--- a/python/satyaml/NORBI.yml
+++ b/python/satyaml/NORBI.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 436.700e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 4800
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
NORBI (46494)
Observation [8949500](https://network.satnogs.org/observations/8949500/)
dd bs=$((4*57600)) if=iq_8949500_57600.raw of=cut.raw skip=118 count=1
gr_satellites norbi --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 4800
![norbi_dev4800](https://github.com/user-attachments/assets/7eae0b7e-f4db-4b44-af8b-598b63b9c998)
