### PR TITLE
Add deviation to NETSAT_2

### DIFF
--- a/python/satyaml/NETSAT_2.yml
+++ b/python/satyaml/NETSAT_2.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.600e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3200
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
NETSAT 2 (46507)
Observation [9035201](https://network.satnogs.org/observations/9035201/)
dd bs=$((4*48000)) if=iq_9035201_48000.raw of=cut.raw skip=72 count=1
gr_satellites 'netsat 2' --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 3200
![netsat2_dev3200](https://github.com/user-attachments/assets/165153ac-f500-4a15-82f3-dfdb3d5f156a)
