### PR TITLE
Add deviation to SelfieSat

### DIFF
--- a/python/satyaml/SelfieSat.yml
+++ b/python/satyaml/SelfieSat.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.500e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
SelfieSat (53951)
Observation [9855383](https://network.satnogs.org/observations/9855383/)
dd bs=$((4*57600)) if=iq_9855383_57600.raw of=cut.raw skip=163 count=1
gr_satellites selfiesat --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3000
![selfiesat_dev3000](https://github.com/user-attachments/assets/02e10a58-3ea0-4614-bed3-ce33b767f85d)
very short frame of only 22 bytes, drowns in the 1s noise surrounding it. 