### PR TITLE
Add deviation to PEARL-1C

### DIFF
--- a/python/satyaml/PEARL-1C.yml
+++ b/python/satyaml/PEARL-1C.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.310e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
PEARL-1C (58342)
Observation [9855528](https://network.satnogs.org/observations/9855528/)
dd bs=$((4*57600)) if=iq_9855528_57600.raw of=cut.raw skip=302 count=1
gr_satellites pearl-1c --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![pearl1c_dev2400](https://github.com/user-attachments/assets/6e165444-24ec-4168-9d89-475963751c59)
