### PR TITLE
Add deviation to SKOLTECH-B1

### DIFF
--- a/python/satyaml/SKOLTECH-B1.yml
+++ b/python/satyaml/SKOLTECH-B1.yml
@@ -31,6 +31,7 @@ transmitters:
     frequency: 435.000e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
Skoltech B1 (53379)
Observation [9855367](https://network.satnogs.org/observations/9855367/)
dd bs=$((4*57600)) if=iq_9855367_57600.raw of=cut.raw skip=314 count=1
gr_satellites SKOLTECH-B1_96.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![skoltechb1_b9600_dev2400](https://github.com/user-attachments/assets/f67986f2-cdea-4017-bbea-ffe2f6d31056)
