### PR TITLE
Add deviation to GREENCUBE

### DIFF
--- a/python/satyaml/GREENCUBE.yml
+++ b/python/satyaml/GREENCUBE.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.310e+6
     modulation: FSK
     baudrate: 300
+    deviation: 125
     framing: AX100 ASM+Golay
     data:
     - *tlm
@@ -22,6 +23,7 @@ transmitters:
     frequency: 435.310e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 500
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
GREENCUBE (53106)
Observation [9847373](https://network.satnogs.org/observations/9847373/)
dd bs=$((4*48000)) if=iq_9847373_48000.raw of=cut.raw skip=252 count=2
gr_satellites GREENCUBE_12.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 500
![greencube_b1200_dev500](https://github.com/user-attachments/assets/69140d27-7ac0-49dd-883f-3c7cfffe5205)

Observation [8842104](https://network.satnogs.org/observations/8842104/)
dd bs=$((4*48000)) if=iq_8842104_48000.wav of=cut.raw skip=693 count=10
gr_satellites GREENCUBE_3.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 125
![greencube_b300_dev125](https://github.com/user-attachments/assets/dac63a8c-ce26-48ed-8b08-935ff4ef5be6)

The 300 baud one was quite hard, I only had a older observation of the 300 baud transmission and it was off by something like 280Hz so when reducing the deviation to it's proper value the signal was out of the passband so the waveform was useless.
I had to run it through a flowgraph to correct the frequency, that is why it is using a .wav