### PR TITLE
Add deviation to NANOZOND-1

### DIFF
--- a/python/satyaml/NANOZOND-1.yml
+++ b/python/satyaml/NANOZOND-1.yml
@@ -22,6 +22,7 @@ transmitters:
     frequency: 437.000e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
Nanozond-1 (57190)
Observation [9855677](https://network.satnogs.org/observations/9855677/)
dd bs=$((4*48000)) if=iq_9855677_48000.raw of=cut.raw skip=259 count=2
gr_satellites NANOZOND-1_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
4k8 FSK downlink
![nanozond1_b48_dev1200](https://github.com/user-attachments/assets/301c4426-e3cf-454e-b2b9-3083a86b8192)
