### PR TITLE
Add deviation to AALTO-1

### DIFF
--- a/python/satyaml/AALTO-1.yml
+++ b/python/satyaml/AALTO-1.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 437.216e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm_ax25
@@ -17,6 +18,7 @@ transmitters:
     frequency: 437.216e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AALTO-1
     data:
     - *tlm_cc1125


### PR DESCRIPTION
AALTO-1 (42775)
Observation [9848488](https://network.satnogs.org/observations/9848488/)
dd bs=$((4*48000)) if=iq_9848488_48000.raw of=cut.raw skip=358 count=1
gr_satellites AALTO-1_ax25.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 3000
![aalto1_dev3000](https://github.com/user-attachments/assets/2c64f5d6-fe9b-463a-93a0-afdaafb85d0b)
