### PR TITLE
Add deviation to VIZARD-METEO

### DIFF
--- a/python/satyaml/VIZARD-METEO.yml
+++ b/python/satyaml/VIZARD-METEO.yml
@@ -24,6 +24,7 @@ transmitters:
     frequency: 437.825e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
VIZARD-meteo (57189)
Observation [9820179](https://network.satnogs.org/observations/9820179/)
dd bs=$((4*57600)) if=iq_9820179_48000.raw of=cut.raw skip=366 count=1
gr_satellites VIZARD-METEO_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
4k8 FSK downlink
![vizmet_b48_dev1200](https://github.com/user-attachments/assets/73e79dec-c1f1-47b7-9b07-48d598b9cb5c)
