### PR TITLE
Add deviation to SSS-2B

### DIFF
--- a/python/satyaml/SSS-2B.yml
+++ b/python/satyaml/SSS-2B.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.800e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
SSS-2B (56184)
Observation [9855327](https://network.satnogs.org/observations/9855327/)
dd bs=$((4*57600)) if=iq_9855327_57600.raw of=cut.raw skip=292 count=1
gr_satellites sss-2b --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3000
![sss2b_dev3000](https://github.com/user-attachments/assets/2caf860c-5269-4d64-adf4-7276e2db8bcf)
