### PR TITLE
Add deviation to MONITOR-3

### DIFF
--- a/python/satyaml/MONITOR-3.yml
+++ b/python/satyaml/MONITOR-3.yml
@@ -24,6 +24,7 @@ transmitters:
     frequency: 435.290e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
Monitor-3 (57180)
Observation [9856020](https://network.satnogs.org/observations/9856020/)
dd bs=$((4*48000)) if=iq_9856020_48000.raw of=cut.raw skip=344 count=2
gr_satellites MONITOR-3_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
4k8 FSK downlink
![monitor3_b48_dev1200](https://github.com/user-attachments/assets/7138cc41-8284-44cf-86ac-0b5a15a74234)
