### PR TITLE
Add deviation to MONITOR-4

### DIFF
--- a/python/satyaml/MONITOR-4.yml
+++ b/python/satyaml/MONITOR-4.yml
@@ -31,6 +31,7 @@ transmitters:
     frequency: 436.080e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
Monitor-4 (57182)
Observation [9855964](https://network.satnogs.org/observations/9855964/)
dd bs=$((4*48000)) if=iq_9855964_48000.raw of=cut.raw skip=54 count=2
gr_satellites MONITOR-4_96.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 2400
9k6 FSK downlink
![monitor4_b96_dev2400](https://github.com/user-attachments/assets/363ad05b-0e97-4bed-911d-9a3110206779)
