### PR TITLE
Add 19k2 and deviation to RESHUCUBE

### DIFF
--- a/python/satyaml/RESHUCUBE.yml
+++ b/python/satyaml/RESHUCUBE.yml
@@ -37,3 +37,11 @@ transmitters:
     framing: USP
     data:
     - *tlm
+  19k2 FSK downlink:
+    frequency: 435.380e+6
+    modulation: FSK
+    baudrate: 19200
+    deviation: 4800
+    framing: USP
+    data:
+    - *tlm


### PR DESCRIPTION
ReshUCube (53382)
Observation [9855507](https://network.satnogs.org/observations/9855507/)
dd bs=$((4*76800)) if=iq_9855507_76800.raw of=cut.raw skip=69 count=1
gr_satellites RESHUCUBE_192.yml --iq --rawint16 cut.raw --samp_rate 76800 --dump_path dump --disable_dc_block --deviation 4800
19k2 FSK downlink
![reshucube_b192_dev4800](https://github.com/user-attachments/assets/4143b951-1712-4d6b-a6e3-52e40e92e09b)
