### PR TITLE
Add deviation to LilacSat-2

### DIFF
--- a/python/satyaml/LilacSat-2.yml
+++ b/python/satyaml/LilacSat-2.yml
@@ -31,6 +31,7 @@ transmitters:
     frequency: 437.225e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 4000
     framing: CCSDS Concatenated
     RS basis: conventional
     frame size: 114
@@ -40,6 +41,7 @@ transmitters:
     frequency: 437.200e+6
     modulation: FSK subaudio
     baudrate: 300
+    deviation: 600
     framing: CCSDS Reed-Solomon
     RS basis: conventional
     frame size: 114


### PR DESCRIPTION
LILACSAT 2 (40908)
Observation [9873340](https://network.satnogs.org/observations/9873340/)
dd bs=$((4*48000)) if=iq_9873340_48000.raw of=cut.raw skip=314 count=2
gr_satellites LilacSat-2_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --hexdump --deviation 4000
4k8 FSK downlink

![lilacsat2_b48_dev4000](https://github.com/user-attachments/assets/f4b11f83-12d1-4bb4-a4b2-e0d56517283a)

Observation [8955140](https://network.satnogs.org/observations/8955140/)
dd bs=$((4*76800)) if=iq_8955140_76800.raw of=cut.raw skip=95 count=10
gr_satellites LilacSat-2_3.yml --iq --rawint16 cut.raw --samp_rate 76800 --dump_path dump --disable_dc_block --hexdump --deviation 600
300baud subaudio downlink

![lilacsat2_b3_dev600](https://github.com/user-attachments/assets/79a6162d-388f-4aeb-b09b-973f8d621d48)
Maybe a bit hard to see, the preamble dominates the histogram.