### PR TITLE
Add deviation to Luojia-1

### DIFF
--- a/python/satyaml/Luojia-1.yml
+++ b/python/satyaml/Luojia-1.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.250e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
Luojia-1 (43485)
Observation [8917576](https://network.satnogs.org/observations/8917576/)
dd bs=$((4*48000)) if=iq_8917576_48000.raw of=cut.raw skip=102 count=1
gr_satellites luojia-1 --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --hexdump --deviation 1600
![luojia1_dev1600](https://github.com/user-attachments/assets/cd3277f7-0361-404d-9b28-b4b0c7805244)
