### PR TITLE
Add deviation to UTMN-2

### DIFF
--- a/python/satyaml/UTMN-2.yml
+++ b/python/satyaml/UTMN-2.yml
@@ -31,6 +31,7 @@ transmitters:
     frequency: 435.485e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
UTMN2 (57203)
Observation [9881203](https://network.satnogs.org/observations/9881203/)
dd bs=$((4*48000)) if=iq_9881203_48000.raw of=cut.raw skip=414 count=1
gr_satellites UTMN-2_96.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 2400
![utmn2_dev2400](https://github.com/user-attachments/assets/ee1178e7-8818-4912-9f85-6bf0df4cb21d)
