### PR TITLE
Add deviation to AISTECHSAT-3

### DIFF
--- a/python/satyaml/AISTECHSAT-3.yml
+++ b/python/satyaml/AISTECHSAT-3.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 436.730e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
AISTECHSAT-3 (44103)
Observation [9022925](https://network.satnogs.org/observations/9022925/)
dd bs=$((4*57600)) if=iq_9022925_57600.raw of=cut.raw skip=73 count=1
gr_satellites AISTECHSAT-3_48.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 1600
![aist3_dev1600](https://github.com/user-attachments/assets/a5d642fc-f649-4c9e-a162-21a604a83591)
