### PR TITLE
Create OOV-Cube.yml

### DIFF
--- a/python/satyaml/OOV-Cube.yml
+++ b/python/satyaml/OOV-Cube.yml
@@ -1,0 +1,16 @@
+name: OOV-Cube
+norad: 60240
+data:
+  &tlm Telemetry:
+    telemetry: snet
+transmitters:
+  1k2 AFSK downlink:
+    frequency: 435.950e+6
+    modulation: AFSK
+    baudrate: 1200
+    af_carrier: 1500
+    deviation: -300
+    fm_deviation: 10000
+    framing: SALSAT
+    data:
+    - *tlm


### PR DESCRIPTION
OOV-Cube (60240)
Observation [9873547](https://network.satnogs.org/observations/9873547/)
dd bs=$((4*48000)) if=iq_48000_9873547.raw of=cut.raw skip=23 count=2
gr_satellites OOV-Cube.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block

![oovcube_afsk1200](https://github.com/user-attachments/assets/fd9d3c34-41b6-4503-9b85-5def5a1b431c)

Basically a copy of SALSAT.yml and example [observation](https://network.satnogs.org/observations/9709269/).
[TU Berlin info](https://www.tu.berlin/en/raumfahrttechnik/research/current-projects/oov-cube)
Thanks to @janvgils for the IQ file

```
((transmitter . 1k2 AFSK downlink) (SNET SrcId . 10))
pdu length =        122 bytes
pdu vector contents =
0000: f3 50 37 48 24 0a 6c 66 a3 73 50 5c 30 88 00 00
0010: 00 01 40 08 71 16 65 05 ab 01 12 56 0f 00 d6 24
0020: 16 40 26 00 0b 00 06 00 17 00 dc 00 e6 1e c9 5e
0030: ce 03 00 87 42 00 be 00 5a 05 0f 00 1d 00 00 0e
0040: 2e 5d 54 1e d0 5e 01 04 70 06 27 00 00 0d 25 00
0050: b0 00 00 82 3d 00 35 00 17 00 10 00 4e 00 5e 00
0060: af 13 3e 00 94 05 c6 00 85 00 00 00 e0 62 61 64
0070: 4b 5d 46 00 00 00 00 00 00 00
```