### PR TITLE
Add deviation to LEDSAT

### DIFF
--- a/python/satyaml/LEDSAT.yml
+++ b/python/satyaml/LEDSAT.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 435.190e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3200
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
LEDSAT (49069)
Observation [9047150](https://network.satnogs.org/observations/9047150/)
dd bs=$((4*57600)) if=iq_9047150_57600.raw of=cut.raw skip=104 count=2
gr_satellites LEDSAT_96.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3200
9k6 FSK downlink
![ledsat_b96_dev3200](https://github.com/user-attachments/assets/34617176-181e-4620-a72e-a83364e96ebb)
