### PR TITLE
Add deviation to BlueWalker_3

### DIFF
--- a/python/satyaml/BlueWalker_3.yml
+++ b/python/satyaml/BlueWalker_3.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.500e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: Light-1
     data:
     - *tlm


### PR DESCRIPTION
BLUEWALKER-3 (53807)
Observation [9893731](https://network.satnogs.org/observations/9893731/)
dd bs=$((4*48000)) if=iq_9893731_48000.raw of=cut.raw skip=202 count=2
gr_satellites bluewalker-3 --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 600

![bw3_dev600](https://github.com/user-attachments/assets/6f36e7d1-f813-4114-845b-93c49be31ddd)
