### PR TITLE
Add deviation to KAFASAT

### DIFF
--- a/python/satyaml/KAFASAT.yml
+++ b/python/satyaml/KAFASAT.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.835e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 300
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
KAFASAT (58317)
Observation [9101526](https://network.satnogs.org/observations/9101526/)
dd bs=$((4*48000)) if=iq_9101526_48000.raw of=cut.raw skip=200 count=2
gr_satellites kafasat --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 300
Har to do a frequency adjust of 1000Hz on the IQ file
![kafasat_dev300](https://github.com/user-attachments/assets/8c6e96cf-3ff0-4413-9e89-b0d4eab51862)
