### PR TITLE
Add deviation to IRIS-A

### DIFF
--- a/python/satyaml/IRIS-A.yml
+++ b/python/satyaml/IRIS-A.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 436.915e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
IRIS-A (51044)
Observation [9020196](https://network.satnogs.org/observations/9020196/)
dd bs=$((4*57600)) if=iq_9020196_57600.raw  of=cut.raw skip=100 count=1
gr_satellites iris-a --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![irisa_dev2400](https://github.com/user-attachments/assets/d5addc6e-a0be-459e-b06a-dbc08f38fa14)
