### PR TITLE
Add deviation to INSPIRE-SAT_7

### DIFF
--- a/python/satyaml/INSPIRE-SAT_7.yml
+++ b/python/satyaml/INSPIRE-SAT_7.yml
@@ -17,6 +17,7 @@ transmitters:
     frequency: 435.200e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 1200
     framing: SPINO
     data:
     - *spino


### PR DESCRIPTION
INSPIRE-SAT 7 (56211)
Observation [9371658](https://network.satnogs.org/observations/9371658/)
dd bs=$((4*48000)) if=iq_9371658_48000.raw  of=cut.raw skip=302 count=2
gr_satellites INSPIRE-SAT_7_2k4.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
2k4 2FSK SPINO payload
![inspiresat7_b24_dev1200](https://github.com/user-attachments/assets/0b6ab3b8-5d76-4cab-8445-40e588f0d57d)
pretty bad weight on the lower bits, DC blocker probably messing with it pretty bad, I don't even get it to demodulate that frame without disabling dc block.