### PR TITLE
Add deviation to INS-2TD

### DIFF
--- a/python/satyaml/INS-2TD.yml
+++ b/python/satyaml/INS-2TD.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.080e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 2000
     framing: AX.25
     data:
     - *tlm


### PR DESCRIPTION
INS-2TD (51658)
Observation [9017323](https://network.satnogs.org/observations/9017323/)
dd bs=$((4*57600)) if=iq_9017323_57600.raw  of=cut.raw skip=101 count=2
gr_satellites ins-2td --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2000
![ins2td_dev2000](https://github.com/user-attachments/assets/e73d3eea-b048-4d3d-bb67-0c075bb4fa4e)
