### PR TITLE
Add deviation to GO-32

### DIFF
--- a/python/satyaml/GO-32.yml
+++ b/python/satyaml/GO-32.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 435.325e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm
@@ -17,6 +18,7 @@ transmitters:
     frequency: 435.225e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3000
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
GO-32 / TECHSAT 1B (25397)
Observation [8986114](https://network.satnogs.org/observations/8986114/)
dd bs=$((4*57600)) if=iq_8986114_57600.raw  of=cut.raw skip=98 count=4
gr_satellites GO-32_96.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 3000
![go32_b96_dev3000](https://github.com/user-attachments/assets/44b18f59-c3be-4fb4-9aae-886d578c8d71)
Quite wonky transmitter, very odd preamble and a bit unstable.
The beginning of the frame looks like this:
![bild](https://github.com/user-attachments/assets/0506db19-f67e-4ac1-aefe-6252048d6fb8)
