### PR TITLE
Add deviation to AISTECHSAT-2

### DIFF
--- a/python/satyaml/AISTECHSAT-2.yml
+++ b/python/satyaml/AISTECHSAT-2.yml
@@ -24,6 +24,7 @@ transmitters:
     frequency: 436.600e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AISTECHSAT-2
     data:
     - *custom
@@ -31,6 +32,7 @@ transmitters:
     frequency: 436.600e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
AISTECHSAT-2 (43768)
Observation [9888488](https://network.satnogs.org/observations/9888488/)
dd bs=$((4*57600)) if=iq_9888488_57600.raw of=cut.raw skip=307 count=2
gr_satellites AISTECHSAT-2_48.yml --iq --rawint16 cut.raw --samp_rate 57600 --hexdump --dump_path dump --disable_dc_block --deviation 1600
4k8 FSK AX100 downlink
![aistec2_b48_dev1600](https://github.com/user-attachments/assets/c677f4fd-6331-4224-ae94-6eb37e3396c2)
