### PR TITLE
Add deviation to CUTE

### DIFF
--- a/python/satyaml/CUTE.yml
+++ b/python/satyaml/CUTE.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.250e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 4800
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
CUTE (49263)
Observation [9033874](https://network.satnogs.org/observations/9033874/)
dd bs=$((4*57600)) if=iq_9033874_57600.raw of=cut.raw skip=102 count=1
gr_satellites cute --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --hexdump --deviation 4800
![cute_dev4800](https://github.com/user-attachments/assets/6cec4c07-22a6-4a48-a30a-6a73161c3171)
