### PR TITLE
Add deviation to CubeSX-Sirius-HSE

### DIFF
--- a/python/satyaml/CubeSX-Sirius-HSE.yml
+++ b/python/satyaml/CubeSX-Sirius-HSE.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 437.050e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
CubeSX-Sirius-HSE (47951)
Observation [8887619](https://network.satnogs.org/observations/8887619/)
dd bs=$((4*48000)) if=iq_8887619_48000.raw of=cut.raw skip=85 count=3
gr_satellites CubeSX-Sirius-HSE_24.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 600
Packet from 2k4 FSK downlink
![cubesxsirhse_b24_dev600](https://github.com/user-attachments/assets/e0a0c567-219e-4275-a81d-cb26bddd4995)
