### PR TITLE
Add deviation to CubeSX-HSE

### DIFF
--- a/python/satyaml/CubeSX-HSE.yml
+++ b/python/satyaml/CubeSX-HSE.yml
@@ -15,6 +15,7 @@ transmitters:
     frequency: 435.650e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: USP
     data:
     - *tlm
@@ -22,6 +23,7 @@ transmitters:
     frequency: 435.650e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
CubeSX-HSE (47952)
Observation [9036314](https://network.satnogs.org/observations/9036314/)
dd bs=$((4*48000)) if=iq_9036314_48000.raw of=cut.raw skip=95 count=3
gr_satellites CubeSX-HSE_24.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 600
Packet from 2k4 FSK downlink
![cubesxhse_b24_dev600](https://github.com/user-attachments/assets/df94bd5b-229e-41ac-b0a1-8c0ec0cf0495)


Observation [8986802](https://network.satnogs.org/observations/8986802/)
dd bs=$((4*48000)) if=iq_8986802_48000.raw of=cut.raw skip=66 count=2
gr_satellites CubeSX-HSE_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
Packet from 4k8 FSK downlink
![cubesxhse_b48_dev1200](https://github.com/user-attachments/assets/d5552d66-ea1b-4dec-b50e-b9de194d6a10)
