### PR TITLE
Add deviation to CubeSX-HSE-2

### DIFF
--- a/python/satyaml/CUBESX-HSE-2.yml
+++ b/python/satyaml/CUBESX-HSE-2.yml
@@ -26,6 +26,7 @@ transmitters:
     frequency: 435.570e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
CubeSX-HSE-2 (53383)
Observation [9497052](https://network.satnogs.org/observations/9497052/)
dd bs=$((4*48000)) if=iq_9497052_48000.raw of=cut.raw skip=250 count=2
gr_satellites CUBESX-HSE-2_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
Packet from 4k8 FSK downlink
![cubesxhse2_b48_dev1200](https://github.com/user-attachments/assets/a171362d-a3b1-471c-9d1d-12f6be6b7663)
