### PR TITLE
Add deviation to CubeSX-HSE-3

### DIFF
--- a/python/satyaml/CUBESX-HSE-3.yml
+++ b/python/satyaml/CUBESX-HSE-3.yml
@@ -17,6 +17,7 @@ transmitters:
     frequency: 436.570e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: USP
     data:
     - *tlm
@@ -24,6 +25,7 @@ transmitters:
     frequency: 436.570e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
57178 - CubeSX-HSE-3 
Observation [9893581](https://network.satnogs.org/observations/9893581/)
dd bs=$((4*48000)) if=iq_9893581_48000.raw of=cut.raw skip=307 count=2
gr_satellites CUBESX-HSE-3_24.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 600
Packet from 2k4 FSK downlink
![cubesxhse3_b24_dev600](https://github.com/user-attachments/assets/4fa5abe9-9eca-4ce5-83b9-29ea25cf599e)


Observation [8986802](https://network.satnogs.org/observations/8986802/)
dd bs=$((4*48000)) if=iq_8986802_48000.raw of=cut.raw skip=66 count=1
gr_satellites CUBESX-HSE-3_48.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
Packet from 4k8 FSK downlink
![cubesxhse3_b48_dev1200](https://github.com/user-attachments/assets/8fccddf9-1b7b-4d3b-ac8c-64eb507e534f)
