### PR TITLE
Add deviation and AFSK to CUBEBUG-2

### DIFF
--- a/python/satyaml/CUBEBUG-2.yml
+++ b/python/satyaml/CUBEBUG-2.yml
@@ -10,6 +10,16 @@ transmitters:
     frequency: 437.445e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2600
     framing: AX.25 G3RUH
+    data:
+    - *tlm
+  1k2 AFSK downlink:
+    frequency: 437.445e+6
+    modulation: AFSK
+    baudrate: 1200
+    af_carrier: 1700
+    deviation: 500
+    framing: AX.25
     data:
     - *tlm


### PR DESCRIPTION
CUBEBUG-2 (39440)
Observation [9042134](https://network.satnogs.org/observations/9042134/)
dd bs=$((4*57600)) if=iq_9042134_57600.raw of=cut.raw skip=75 count=1
gr_satellites cubebug-2 --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2600
Packet from 9k6 FSK downlink
bit odd deviation, but 2400 looked worse.
![cubebug2_b96_dev2600](https://github.com/user-attachments/assets/18ae29ae-87f9-4d58-b2c7-4da34509514c)

And now to the fun part...
Observation [9893588](https://network.satnogs.org/observations/9893588/)
sox -t raw -b 16 -e signed-integer -r 48000 -c 2 iq_9893588_48000.raw iq_9893588_48000.wav
Cutting out the frames in audacity and then adjusting the center frequency -700 Hz resulting in iq_9893588_48000_adj.wav
gr_satellites CUBEBUG-2_afsk.yml --iq --wavfile iq_9893588_48000_adj.wav --dump_path dump
```
Packet from 1k2 AFSK downlink
Container:
    header = Container:
        addresses = ListContainer:
            Container:
                callsign = u'CQ' (total 2)
                ssid = Container:
                    ch = False
                    ssid = 0
                    extension = False
            Container:
                callsign = u'CUBEB2' (total 6)
                ssid = Container:
                    ch = True
                    ssid = 6
                    extension = True
        control = 0x03
        pid = 0xF0
    info = b"\xff\xff\xf0\x00\x00\x0c'\x00;F\x05\x00\x02\xe7\x18\x00\x00N@\x00\x00\x00\x00\x0f\x00\x02\x02\\\x0b\xae\x03\xff\x02\xbe\x03\xff\x00\x02\x03\xff\x03\xff\x03\x94\x03>\x03?\x03\xff\xfc\x18\x08\x13\xdcm&\xc7$k\x00\xd9\xff\xa8\x00z\x00\x0e\xfe\xb7\x00\n\xff\xfclM\n\x9f" (total 78)
```
![cubebug2_afsk1200](https://github.com/user-attachments/assets/0b2b4e7a-5162-4d75-8f87-98097c6497b2)
I wasn't able to determine the fm_deviation