### PR TITLE
Add deviation to CIRBE

### DIFF
--- a/python/satyaml/CIRBE.yml
+++ b/python/satyaml/CIRBE.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.250e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 4800
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
CIRBE (56188)
Observation [9036243](https://network.satnogs.org/observations/9036243/)
dd bs=$((4*57600)) if=iq_9036243_57600.raw of=cut.raw skip=71 count=1
gr_satellites CIRBE_96.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --hexdump --deviation 4800
transmitter . 9k6 FSK downlink
![cirbe_b96_dev4800](https://github.com/user-attachments/assets/c746c68f-dbb8-471b-9b80-24eba98304ca)
