### PR TITLE
Add deviation to al-Farabi-2

### DIFF
--- a/python/satyaml/al-Farabi-2.yml
+++ b/python/satyaml/al-Farabi-2.yml
@@ -10,6 +10,7 @@ transmitters:
     frequency: 436.500e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
al-Farabi-2 (43805)
Observation [9017837](https://network.satnogs.org/observations/9017837/)
dd bs=$((4*48000)) if=iq_9017837_48000.raw of=cut.raw skip=77 count=1
rawint_tune.py -i cut.raw -o cut_adj.raw -f 1000
gr_satellites al-Farabi-2 --iq --rawint16 cut_adj.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200

![alfarabi2_dev1200](https://github.com/user-attachments/assets/74cd4825-a920-4d07-aa7d-789ef739b75b)

a bit of a sketchy one, as the satellite seems silent now and I only have recordings of it behaving erratically.
the histogram is thrown off as the transmitter mostly sends 01010101 and these have a lower amplitude, the middle.