### PR TITLE
Add deviation to Hayasat

### DIFF
--- a/python/satyaml/Hayasat.yml
+++ b/python/satyaml/Hayasat.yml
@@ -9,6 +9,7 @@ transmitters:
     frequency: 437.020e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
Hayasat (58471)
Observation [9893461](https://network.satnogs.org/observations/9893461/)
dd bs=$((4*57600)) if=iq_9893461_57600.raw of=cut.raw skip=301 count=1
gr_satellites hayasat --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 2400
![hayasat_dev2400](https://github.com/user-attachments/assets/91ebc77f-2f27-4431-8a5d-9c5229bd41cc)
