### PR TITLE
Add deviation to KSU_CubeSat

### DIFF
--- a/python/satyaml/KSU_CubeSat.yml
+++ b/python/satyaml/KSU_CubeSat.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.130e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
KSU-Cubesat (47954)
Observation [8990398](https://network.satnogs.org/observations/8990398/)
dd bs=$((4*48000)) if=iq_8990398_48000.raw of=cut.raw skip=110 count=1
gr_satellites "ksu cubesat" --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
![ksucube_dev1200](https://github.com/user-attachments/assets/2da3b1ff-ecca-4dfe-836b-9411cc7191b4)
