### PR TITLE
Add deviation and 19k2 to ISOI

### DIFF
--- a/python/satyaml/ISOI.yml
+++ b/python/satyaml/ISOI.yml
@@ -36,3 +36,11 @@ transmitters:
     framing: USP
     data:
     - *tlm
+  19k2 FSK downlink:
+    frequency: 437.650e+6
+    modulation: FSK
+    baudrate: 19200
+    deviation: 4800
+    framing: USP
+    data:
+    - *tlm


### PR DESCRIPTION
ISOI (53381)
Observation [9638582](https://network.satnogs.org/observations/9638582/)
dd bs=$((4*48000)) if=iq_9638582_48000.raw of=cut.raw skip=125 count=1
gr_satellites ISOI_192.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 
![isoi_b192_dev4800](https://github.com/user-attachments/assets/1a443ddc-c5fa-4d8c-b1b8-a0c5d8792707)
```
-> Packet from 19k2 FSK downlink
Container:
    header = Container:
        addresses = ListContainer:
            Container:
                callsign = u'R2ANF' (total 5)
                ssid = Container:
                    ch = False
                    ssid = 0
                    extension = False
            Container:
                callsign = u'RS19S' (total 5)
                ssid = Container:
                    ch = False
                    ssid = 1
                    extension = True
        control = 0x00
        pid = 0xF0
    info = b'\x16B\x02\x00\x01\x00B\x00\xe5\x12\xa1\x04-\x15\xd9\x00c\x04\x00\x00N\x00\x00\x00\x1e\x00\x00\x00\x00\x00\x04\x00\x05\x00\x05\x00\x04\x00\x00 \x00\x00\xf4\x1e\xe4\x0e\x00\x00\xec\xa8_fj\x04\x0e\x0c\xffv#\x1d\xd1\x0e\xed\xa8_f\xe2\x0e\x00\x00\x1e\x00\x10\x1f' (total 74)
```