### PR TITLE
Add deviation to INSPIRESat-1

### DIFF
--- a/python/satyaml/INSPIRESat-1.yml
+++ b/python/satyaml/INSPIRESat-1.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 437.500e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 4800
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
INSPIRESat-1 (51657)
Observation [9893432](https://network.satnogs.org/observations/9893432/)
dd bs=$((4*57600)) if=iq_9893432_57600.raw of=cut.raw skip=265 count=2
gr_satellites inspiresat-1 --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --hexdump --deviation 4800
![inspiresat1_dev4800](https://github.com/user-attachments/assets/0553903a-5638-4091-ab18-e77480505c52)
