### PR TITLE
Add deviation to ARCCUBE-1

### DIFF
--- a/python/satyaml/ARCCUBE-1.yml
+++ b/python/satyaml/ARCCUBE-1.yml
@@ -17,6 +17,7 @@ transmitters:
     frequency: 437.600e+6
     modulation: FSK
     baudrate: 2400
+    deviation: 600
     framing: USP
     data:
     - *tlm


### PR DESCRIPTION
ArcCube-01 (57205)
Observation [9893845](https://network.satnogs.org/observations/9893845/)
dd bs=$((4*57600)) if=iq_9893845_57600.raw of=cut.raw skip=303 count=3
gr_satellites ARCCUBE-1_24.yml --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --deviation 600
Packet from 2k4 FSK downlink
![arccube1_dev600](https://github.com/user-attachments/assets/44111da2-32dc-444a-ab25-75bec44c8564)
