### PR TITLE
Add deviation to BEESAT-2

### DIFF
--- a/python/satyaml/BEESAT-2.yml
+++ b/python/satyaml/BEESAT-2.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.950e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1800
     framing: Mobitex-NX
     data:
     - *tlm


### PR DESCRIPTION
BEESAT-2 (39136)
Observation [8942955](https://network.satnogs.org/observations/8942955/)
dd bs=$((4*48000)) if=iq_8942955_48000.raw of=cut.raw skip=97 count=1
gr_satellites beesat-2 --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1800
![beesat2_dev1800](https://github.com/user-attachments/assets/79a624c4-f2c7-4b89-9bdd-1fc3c95dd018)

Another really wavy transmission, just as BEESAT-9 (same deviation), histogram seems to be a bit off, zoomed in on a pretty straight part.