### PR TITLE
Add deviation to D-STAR_ONE_Sparrow

### DIFF
--- a/python/satyaml/D-STAR_ONE_Sparrow.yml
+++ b/python/satyaml/D-STAR_ONE_Sparrow.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.700e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex
     data:
     - *tlm


### PR DESCRIPTION
D-Star ONE Sparrow (43881)
Observation [9025907](https://network.satnogs.org/observations/9025907/)
dd bs=$((4*48000)) if=iq_9025907_48000.raw of=cut.raw skip=106 count=1
gr_satellites "D-STAR ONE Sparrow" --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --hexdump --deviation 1200
![dstar1_sparrow_dev1200](https://github.com/user-attachments/assets/af013d9f-dbeb-4ac4-8ed5-e8321615cf47)
