### PR TITLE
Add deviation to D-STAR_ONE_iSat

### DIFF
--- a/python/satyaml/D-STAR_ONE_iSat.yml
+++ b/python/satyaml/D-STAR_ONE_iSat.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.700e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 1200
     framing: Mobitex
     data:
     - *tlm


### PR DESCRIPTION
D-Star ONE iSat (43879)
Observation [9025904](https://network.satnogs.org/observations/9025904/)
dd bs=$((4*48000)) if=iq_9025904_48000.raw of=cut.raw skip=70 count=1
gr_satellites "D-STAR ONE iSat" --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --hexdump --deviation 1200
![dstar1_isat_dev1200](https://github.com/user-attachments/assets/960381cc-7f4b-454b-85a3-de2c0d3b0f66)
