### PR TITLE
Add deviation to Astrocast_0_1, change frequency

### DIFF
--- a/python/satyaml/Astrocast_0_1.yml
+++ b/python/satyaml/Astrocast_0_1.yml
@@ -7,23 +7,26 @@ data:
     unknown
 transmitters:
   1k2 FSK FX.25 NRZ-I downlink:
-    frequency: 437.175e+6
+    frequency: 437.150e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 1200
     framing: Astrocast FX.25 NRZ-I
     data:
     - *tlm
   1k2 FSK FX.25 NRZ downlink:
-    frequency: 437.175e+6
+    frequency: 437.150e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 1200
     framing: Astrocast FX.25 NRZ
     data:
     - *tlm
   9k6 FSK downlink:
-    frequency: 437.175e+6
+    frequency: 437.150e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 4800
     framing: CCSDS Reed-Solomon
     frame size: 1115
     RS basis: dual


### PR DESCRIPTION
Astrocast 0.1 (43798) 
Observation [10025815](https://network.satnogs.org/observations/10025815/)
dd bs=$((4*48000)) if=iq_10025815_48000.raw of=cut.raw skip=314 count=3
gr_satellites Astrocast_0_1_96.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 4800
9k6
![astrocast01_b96_dev4800](https://github.com/user-attachments/assets/7522a6f8-aa3c-4fcc-8656-0aa904d1ba36)

Observation [10025814](https://network.satnogs.org/observations/10025814/)
dd bs=$((4*48000)) if=iq_10025814_48000.raw of=cut.raw skip=318 count=3
gr_satellites Astrocast_0_1_12.yml --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 1200
1k2
![astrocast01_b12_dev1200](https://github.com/user-attachments/assets/2ebe7dfa-57b9-437b-ba3e-553616b76de8)
