### PR TITLE
Add deviation and altnames to CUBE-L

### DIFF
--- a/python/satyaml/CUBE-L.yml
+++ b/python/satyaml/CUBE-L.yml
@@ -1,5 +1,8 @@
 name: CUBE-L
 norad: 47448
+alternative_names:
+  - PIXL-1
+  - OSIRIS4CubeSat
 data:
     &tlm Telemetry:
         telemetry: csp
@@ -8,6 +11,7 @@ transmitters:
     frequency: 400.575e+6
     modulation: FSK
     baudrate: 9600
+    deviation: 3200
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
CUBE-L (47448)
Observation [9893599](https://network.satnogs.org/observations/9893599/)
dd bs=$((4*57600)) if=iq_9893599_57600.raw of=cut.raw skip=399 count=1
gr_satellites cube-l --iq --rawint16 cut.raw --samp_rate 57600 --dump_path dump --disable_dc_block --hexdump --deviation 3200
![cubel_dev3200](https://github.com/user-attachments/assets/6f43e069-51ed-4385-822c-2c6817d19fa5)
