### PR TITLE
Add CUAVA-2 and WS-1 satellites

### DIFF
--- a/python/satyaml/CUAVA-2.yml
+++ b/python/satyaml/CUAVA-2.yml
@@ -1,0 +1,13 @@
+name: CUAVA-2
+norad: 98858
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  1k2 BPSK downlink:
+    frequency: 400.65e+6
+    modulation: BPSK
+    baudrate: 1200
+    framing: AX.25 G3RUH
+    data:
+    - *tlm

--- a/python/satyaml/WS-1.yml
+++ b/python/satyaml/WS-1.yml
@@ -1,0 +1,15 @@
+name: WS-1
+alternative_names: 
+  - Waratah Seed-1
+norad: 98849
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  1k2 BPSK downlink:
+    frequency: 400.65e+6
+    modulation: BPSK
+    baudrate: 1200
+    framing: AX.25 G3RUH
+    data:
+    - *tlm


### PR DESCRIPTION
As a representative of the University of Sydney team, I'd like to add the CUAVA-2
and Waratah Seed-1 CubeSats. 

Please let me know if this is not enough for an endorsement of
commercial satellites.