### PR TITLE
Add deviation to BCCSAT_1

### DIFF
--- a/python/satyaml/BCCSAT_1.yml
+++ b/python/satyaml/BCCSAT_1.yml
@@ -8,6 +8,7 @@ transmitters:
     frequency: 435.635e+6
     modulation: FSK
     baudrate: 4800
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm


### PR DESCRIPTION
BCCSAT 1 (48041)
Observation [10041302](https://network.satnogs.org/observations/10041302/)
dd bs=$((4*48000)) if=iq_10041302_48000.raw of=cut.raw skip=190 count=3
gr_satellites "bccsat 1" --iq --rawint16 cut.raw --samp_rate 48000 --dump_path dump --disable_dc_block --deviation 2400
![bccsat1_dev2400](https://github.com/user-attachments/assets/12c25bf1-0b64-49c6-bbb6-fa9aa78a24eb)
histogram a bit off due to the persistant signal at -1