### PR TITLE
Add VDNH-80 satellite

### DIFF
--- a/python/satyaml/VDNH-80.yml
+++ b/python/satyaml/VDNH-80.yml
@@ -1,0 +1,14 @@
+name: VDNH-80
+norad: 44392
+data:
+  &tlm Telemetry:
+    unknown
+transmitters:
+  4k8 FSK downlink:
+    frequency: 436.500e+6
+    modulation: FSK
+    baudrate: 4800
+    deviation: 1200
+    framing: Mobitex
+    data:
+    - *tlm


### PR DESCRIPTION
VDNH-80 (44392)
Observation [9045692](https://network.satnogs.org/observations/9045692/)
dd bs=$((4*48000)) if=iq_9045692_48000.raw of=cut.raw skip=106 count=1
gr_satellites VDNH-80.yml --iq --rawint16 cut.raw --samp_rate 48e3 --dump_path dump --disable_dc_block --deviation 1200
![vdnh80_dev1200](https://github.com/user-attachments/assets/a0b9628c-82f0-46d3-bb4f-3fd5300f26c7)
althou just decayed :D SSA

```
* MESSAGE DEBUG PRINT PDU VERBOSE *
((transmitter . 4k8 FSK downlink) . 1)
pdu_length = 116
contents =
0000: 5b 06 6c a3 f6 d6 d0 01 81 07 00 00 00 00 00 00
0010: 00 b1 00 63 09 ab 0c 50 0a a0 0a f3 01 5b 00 08
0020: 00 02 00 04 02 52 00 03 08 a2 00 07 00 02 00 04
0030: 00 04 00 21 00 03 00 0a 00 04 00 07 00 04 00 04
0040: 00 04 00 00 00 02 00 00 00 04 08 57 0a 60 00 08
0050: e0 00 03 00 dd fa 00 00 5a 01 00 00 00 5c 02 01
0060: 10 01 ff ff ff ff ff ff ff ff ff ff 74 56 aa 00
0070: 00 00 00 bb
***********************************
```