### PR TITLE
Change savefig dir in waveform_plot

### DIFF
--- a/tools/waveform_plot.py
+++ b/tools/waveform_plot.py
@@ -26,6 +26,7 @@ def waveform_plot(a: dict):
         return 1
     print(f"Plotting {a['waveform']}")
 
+    plt.rcParams['savefig.directory'] = "."
     fig, (sig, hst) = plt.subplots(1, 2, sharey=True, figsize=(10, 6), tight_layout=True,
                                    gridspec_kw={'width_ratios': [0.8, 0.2]})
     plt.yticks(np.arange(-5, 5, 0.1), minor=True)
@@ -47,6 +48,7 @@ def waveform_plot(a: dict):
         hst.hist(x, density=True, bins=1000, orientation='horizontal')
 
     plt.show()
+    plt.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This sets the working dir to the same as where the script was launched, and hopefully closer to where the resulting images is to be saved.
https://matplotlib.org/stable/users/explain/customizing.html#the-default-matplotlibrc-file
Closing the plot might alleviate the issue where displaying the plot twice in some older versions.