### PR TITLE
Update Bluebird_04.yml

### DIFF
--- a/python/satyaml/Bluebird_04.yml
+++ b/python/satyaml/Bluebird_04.yml
@@ -1,11 +1,11 @@
 name: Bluebird 04
-norad: 98801
+norad: 61049
 data:
   &tlm Telemetry:
     unknown
 transmitters:
   2k4 FSK downlink:
-    frequency: 435.900e+6
+    frequency: 432.300e+6
     modulation: FSK
     baudrate: 2400
     deviation: 600


### PR DESCRIPTION
satellite | frequency | Object ID | Celestrak Name | obs check
-- | -- | -- | -- | --
  |   |   |   |  
Bluebird-1 | 439500 | 61047 | SPACEMOBILE-001 | https://network.satnogs.org/observations/10269114/
Bluebird-2 | 435900 | 61048 | SPACEMOBILE-002 | https://network.satnogs.org/observations/10268697/
Bluebird-3 | 434100 | 61045 | SPACEMOBILE-003 | https://network.satnogs.org/observations/10268972/
Bluebird-4 | 432300 | 61049 | SPACEMOBILE-004 | https://network.satnogs.org/observations/10268867/
Bluebird-5 | 430500 | 61046 | SPACEMOBILE-005 | https://network.satnogs.org/observations/10268485/