### PR TITLE
Added new deframer for GEOSCAN satellite platform

### DIFF
--- a/grc/components/deframers/satellites_geoscan_deframer.block.yml
+++ b/grc/components/deframers/satellites_geoscan_deframer.block.yml
@@ -41,6 +41,7 @@ documentation: |-
         PDUs with the deframed GEOSCAN packets
 
     Parameters:
+        Frame size: size of the decode frame in bytes
         Syncword threshold: number of bit errors to allow in syncword detection
         Command line options: options to pass down to the block, following the syntax of the gr_satellites command line tool
 

--- a/grc/components/deframers/satellites_geoscan_deframer.block.yml
+++ b/grc/components/deframers/satellites_geoscan_deframer.block.yml
@@ -12,7 +12,7 @@ parameters:
     dtype: string
     default: '""'
     hide: part
--   id: packet_length
+-   id: frame_size
     label: Frame length (bytes)
     dtype: int
     default: 66
@@ -27,7 +27,7 @@ outputs:
 
 templates:
     imports: import satellites.components.deframers
-    make: satellites.components.deframers.geoscan_deframer(packet_length = ${packet_length}, syncword_threshold = ${threshold}, options=${options})
+    make: satellites.components.deframers.geoscan_deframer(frame_size = ${frame_size}, syncword_threshold = ${threshold}, options=${options})
 
 documentation: |-
     Deframes GEOSCAN custom packets

--- a/grc/components/deframers/satellites_geoscan_deframer.block.yml
+++ b/grc/components/deframers/satellites_geoscan_deframer.block.yml
@@ -12,10 +12,10 @@ parameters:
     dtype: string
     default: '""'
     hide: part
--   id: new_geoscan_platform
-    label: New GEOSCAN Platform deframer
+-   id: packet_length
+    label: Frame length (bytes)
     dtype: int
-    default: 0
+    default: 66
 
 inputs:
 -   domain: stream
@@ -27,10 +27,10 @@ outputs:
 
 templates:
     imports: import satellites.components.deframers
-    make: satellites.components.deframers.geoscan_deframer(new_geoscan_platform = ${new_geoscan_platform}, syncword_threshold = ${threshold}, options=${options})
+    make: satellites.components.deframers.geoscan_deframer(packet_length = ${packet_length}, syncword_threshold = ${threshold}, options=${options})
 
 documentation: |-
-    Deframes AALTO-1 custom packets
+    Deframes GEOSCAN custom packets
 
     The frames are transmitted by a Texas Intruments CC1125 transceiver with a PN9 scrambler and the built-in CRC.
 

--- a/grc/components/deframers/satellites_geoscan_deframer.block.yml
+++ b/grc/components/deframers/satellites_geoscan_deframer.block.yml
@@ -12,6 +12,10 @@ parameters:
     dtype: string
     default: '""'
     hide: part
+-   id: new_geoscan_platform
+    label: New GEOSCAN Platform deframer
+    dtype: int
+    default: 0
 
 inputs:
 -   domain: stream
@@ -23,7 +27,7 @@ outputs:
 
 templates:
     imports: import satellites.components.deframers
-    make: satellites.components.deframers.geoscan_deframer(syncword_threshold = ${threshold}, options=${options})
+    make: satellites.components.deframers.geoscan_deframer(new_geoscan_platform = ${new_geoscan_platform}, syncword_threshold = ${threshold}, options=${options})
 
 documentation: |-
     Deframes AALTO-1 custom packets

--- a/python/components/deframers/geoscan_deframer.py
+++ b/python/components/deframers/geoscan_deframer.py
@@ -33,7 +33,7 @@ class geoscan_deframer(gr.hier_block2, options_block):
         syncword_threshold: number of bit errors allowed in syncword (int)
         options: Options from argparse
     """
-    def __init__(self, syncword_threshold=None, options=None):
+    def __init__(self,new_geoscan_platform=False syncword_threshold=None, options=None):
         gr.hier_block2.__init__(
             self,
             'geoscan_deframer',
@@ -45,10 +45,15 @@ class geoscan_deframer(gr.hier_block2, options_block):
 
         if syncword_threshold is None:
             syncword_threshold = self.options.syncword_threshold
+        
+        if new_geoscan_platform:
+            self.packlen=74
+        else:
+            self.packlen=66
 
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
-            packlen=66, sync=_syncword, threshold=syncword_threshold)
+            packlen=self.packlen, sync=_syncword, threshold=syncword_threshold)
         self.scrambler = pn9_scrambler()
         self.crc = crc16_cc11xx()
 

--- a/python/components/deframers/geoscan_deframer.py
+++ b/python/components/deframers/geoscan_deframer.py
@@ -31,6 +31,7 @@ class geoscan_deframer(gr.hier_block2, options_block):
 
     Args:
         syncword_threshold: number of bit errors allowed in syncword (int)
+        frame_size: size of the decode frame in bytes
         options: Options from argparse
     """
     def __init__(self, frame_size=66, syncword_threshold=None, options=None):
@@ -44,7 +45,7 @@ class geoscan_deframer(gr.hier_block2, options_block):
         self.message_port_register_hier_out('out')
 
         if syncword_threshold is None:
-            syncword_threshold = self.options.syncword_threshold     
+            syncword_threshold = self.options.syncword_threshold
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
             packlen=frame_size, sync=_syncword, threshold=syncword_threshold)

--- a/python/components/deframers/geoscan_deframer.py
+++ b/python/components/deframers/geoscan_deframer.py
@@ -44,8 +44,7 @@ class geoscan_deframer(gr.hier_block2, options_block):
         self.message_port_register_hier_out('out')
 
         if syncword_threshold is None:
-            syncword_threshold = self.options.syncword_threshold
-        
+            syncword_threshold = self.options.syncword_threshold     
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
             packlen=frame_size, sync=_syncword, threshold=syncword_threshold)

--- a/python/components/deframers/geoscan_deframer.py
+++ b/python/components/deframers/geoscan_deframer.py
@@ -33,7 +33,7 @@ class geoscan_deframer(gr.hier_block2, options_block):
         syncword_threshold: number of bit errors allowed in syncword (int)
         options: Options from argparse
     """
-    def __init__(self,new_geoscan_platform=False syncword_threshold=None, options=None):
+    def __init__(self,new_geoscan_platform=False, syncword_threshold=None, options=None):
         gr.hier_block2.__init__(
             self,
             'geoscan_deframer',

--- a/python/components/deframers/geoscan_deframer.py
+++ b/python/components/deframers/geoscan_deframer.py
@@ -33,7 +33,7 @@ class geoscan_deframer(gr.hier_block2, options_block):
         syncword_threshold: number of bit errors allowed in syncword (int)
         options: Options from argparse
     """
-    def __init__(self, packet_length=None, syncword_threshold=None, options=None):
+    def __init__(self, frame_size=66, syncword_threshold=None, options=None):
         gr.hier_block2.__init__(
             self,
             'geoscan_deframer',
@@ -46,12 +46,9 @@ class geoscan_deframer(gr.hier_block2, options_block):
         if syncword_threshold is None:
             syncword_threshold = self.options.syncword_threshold
         
-        if packet_length is None:
-            packet_length = self.options.packet_length
-        
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
-            packlen=packet_length, sync=_syncword, threshold=syncword_threshold)
+            packlen=frame_size, sync=_syncword, threshold=syncword_threshold)
         self.scrambler = pn9_scrambler()
         self.crc = crc16_cc11xx()
 
@@ -61,7 +58,6 @@ class geoscan_deframer(gr.hier_block2, options_block):
         self.msg_connect((self.crc, 'ok'), (self, 'out'))
 
     _default_sync_threshold = 4
-    _default_packet_length = 66
 
     @classmethod
     def add_options(cls, parser):
@@ -72,7 +68,3 @@ class geoscan_deframer(gr.hier_block2, options_block):
             '--syncword_threshold', type=int,
             default=cls._default_sync_threshold,
             help='Syncword bit errors [default=%(default)r]')
-        parser.add_argument(
-            '--packet_length', type=int,
-            default=cls._default_packet_length,
-            help='Frame length in bytes [default=%(default)r]')

--- a/python/satyaml/GEOSCAN-EDELVEIS.yml
+++ b/python/satyaml/GEOSCAN-EDELVEIS.yml
@@ -12,5 +12,6 @@ transmitters:
      modulation: FSK
      baudrate: 9600
      framing: GEOSCAN
+     frame size: 66
      data:
      - *tlm

--- a/python/satyaml/STRATOSAT-TK1.yml
+++ b/python/satyaml/STRATOSAT-TK1.yml
@@ -12,5 +12,6 @@ transmitters:
      baudrate: 9600
      deviation: 4800
      framing: GEOSCAN
+     frame size: 66
      data:
      - *tlm


### PR DESCRIPTION
Added new deframer for GEOSCAN satellite platform. New packet length is 74 bytes. I changed the block by adding a parameter to select packet length for old and new satellite platform