### PR TITLE
doppler: correct error when opening file failed

### DIFF
--- a/lib/doppler_correction_impl.cc
+++ b/lib/doppler_correction_impl.cc
@@ -10,7 +10,7 @@
 #include "doppler_correction_impl.h"
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
-#include <cstdio>
+#include <spdlog/fmt/fmt.h>
 #include <fstream>
 #include <stdexcept>
 
@@ -50,6 +50,10 @@ doppler_correction_impl::~doppler_correction_impl() {}
 void doppler_correction_impl::read_doppler_file(std::string& filename)
 {
     std::ifstream input_file(filename);
+    if (!input_file.good()) {
+        throw std::runtime_error(
+            fmt::format("error opening Doppler file '{}'", filename));
+    }
     double time;
     double frequency;
 


### PR DESCRIPTION
When using gr-satellites from an external project, it was a bit confusing to see format errors when they were actually just errors of files not being found.
