### PR TITLE
'Check address': Add check for digipeater callsign and hbit

### DIFF
--- a/grc/satellites_check_address.block.yml
+++ b/grc/satellites_check_address.block.yml
@@ -13,6 +13,9 @@ parameters:
     dtype: string
     options: ['"from"', '"to"']
     option_labels: [From, To]
+-   id: digicallsign
+    label: Digicallsign
+    dtype: string
 
 inputs:
 -   domain: message
@@ -28,6 +31,6 @@ outputs:
 
 templates:
     imports: import satellites
-    make: satellites.check_address(${address}, ${direction})
+    make: satellites.check_address(${address}, ${direction}, ${digicallsign})
 
 file_format: 1

--- a/python/check_address.py
+++ b/python/check_address.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright 2017 Daniel Estevez <daniel@destevez.net>
@@ -16,18 +16,23 @@ import pmt
 
 
 class check_address(gr.basic_block):
+
     """docstring for block check_address"""
-    def __init__(self, address, direction):
-        gr.basic_block.__init__(
-            self,
-            name='check_address',
-            in_sig=[],
-            out_sig=[])
+
+    def __init__(
+        self,
+        address,
+        direction,
+        digicallsign,
+        ):
+        gr.basic_block.__init__(self, name='check_address', in_sig=[],
+                                out_sig=[])
 
         a = address.split('-')
         self.callsign = a[0]
-        self.ssid = int(a[1]) if len(a) > 1 else None
+        self.ssid = (int(a[0x01]) if len(a) > 0x01 else None)
         self.direction = direction
+        self.digicallsign = digicallsign
 
         self.message_port_register_in(pmt.intern('in'))
         self.set_msg_handler(pmt.intern('in'), self.handle_msg)
@@ -37,12 +42,13 @@ class check_address(gr.basic_block):
     def handle_msg(self, msg_pmt):
         msg = pmt.cdr(msg_pmt)
         if not pmt.is_u8vector(msg):
-            print('[ERROR] Received invalid message type. Expected u8vector')
+            print '[ERROR] Received invalid message type. Expected u8vector'
             return
         packet = bytes(pmt.u8vector_elements(msg))
 
         # Check packet length.
         # An AX.25 header with 2 addresses, control and PID is 16 bytes.
+
         if len(packet) < 16:
             self.message_port_pub(pmt.intern('fail'), msg_pmt)
             return
@@ -52,14 +58,51 @@ class check_address(gr.basic_block):
         else:
             address = packet[7:14]
 
-        callsign = [c >> 1 for c in address[:6]]
-        callsign = bytes(callsign).decode('ascii').rstrip(' ')
-        ssid = (address[6] >> 1) & 0x0f
+        if len(packet) > 20:
 
-        if (callsign != self.callsign
-                or (self.ssid is not None and ssid != self.ssid)):
-            # Incorrect address
-            self.message_port_pub(pmt.intern('fail'), msg_pmt)
-        else:
-            # Correct address
+## hbit  (most significant bit after digi callsign) (set to 1 in case of digipeated message)
+
+            hbit = packet[20] >> 7
+
+## digi callsign
+
+            digi = [c >> 0x01 for c in packet[14:20]]
+
+## error handling
+
+            try:
+                digi = bytes(digi).decode('ascii').rstrip(' ')
+            except UnicodeDecodeError:
+
+                print 'Not to ASCII convertable string detected.'
+
+## extension bit (least significant bit after sender callsign) (set to 0 in case of digi callsign follows)
+
+        ebit = packet[13] & 0x01
+
+        callsign = [c >> 0x01 for c in address[:6]]
+
+## error handling
+
+        try:
+            callsign = bytes(callsign).decode('ascii').rstrip(' ')
+        except UnicodeDecodeError:
+
+            print 'Not to ASCII convertable string detected.'
+
+        ssid = address[6] >> 0x01 & 0x0f
+
+## altered if sentence
+
+        if callsign == self.callsign and ((ssid
+                == self.ssid if self.ssid is not None else True)) \
+            or ebit == 0 and hbit == 0x01 and digi == self.digicallsign:
+
+            # match
+
             self.message_port_pub(pmt.intern('ok'), msg_pmt)
+        else:
+
+            # no match
+
+            self.message_port_pub(pmt.intern('fail'), msg_pmt)


### PR DESCRIPTION
Adds check for digipeater callsign and hbit set.
In combination with 'telemetry forwarder' good to filter out decoded own frames during transmitting (near TCA).