### PR TITLE
Add check for digipeater callsign and hbit to block 'Check address'

### DIFF
--- a/grc/satellites_check_address.block.yml
+++ b/grc/satellites_check_address.block.yml
@@ -33,4 +33,16 @@ templates:
     imports: import satellites
     make: satellites.check_address(${address}, ${direction}, ${digicallsign})
 
+documentation: |-
+    Enter an address (choose "from" for source or "to" for destination callsign) and/or enter a digipeater callsign.
+    The address callsign may have a SSID, the digipeater callsign must not have a SSID.
+    
+    Example and results:
+    Address: PCSAT-1 (from)
+    Digicallsign: W3ADO
+
+    Every frame with PCSAT-1 as source callsign will be forwarded to output port "ok".
+    Every frame with "via" W3ADO (SSID is arbitrary) and hbit set (usually marked with an asterisk (*) to show that it was digipeated) will be forwarded to output port "ok".
+    Everything else will be forwarded to output port "fail".
+    
 file_format: 1

--- a/grc/satellites_check_address.block.yml
+++ b/grc/satellites_check_address.block.yml
@@ -35,7 +35,9 @@ templates:
     make: satellites.check_address(${address}, ${direction}, ${digicallsign})
 
 documentation: |-
-    Enter an address (choose "from" for source or "to" for destination callsign) and/or enter a digipeater callsign.
+    Enter either an address (choose "from" for source or "to" for destination callsign) or a digipeater callsign or both.
+    The logical connective between 'address' and 'digipeater callsign' is an inclusive disjunction (OR).
+    If at least one callsign of both matches, the frame is passed to output port "ok".
     The address callsign may have a SSID, the digipeater callsign must not have a SSID.
     
     Example and results:

--- a/grc/satellites_check_address.block.yml
+++ b/grc/satellites_check_address.block.yml
@@ -13,6 +13,9 @@ parameters:
     dtype: string
     options: ['"from"', '"to"']
     option_labels: [From, To]
+-   id: digicallsign
+    label: Digicallsign
+    dtype: string
 
 inputs:
 -   domain: message
@@ -28,6 +31,6 @@ outputs:
 
 templates:
     imports: import satellites
-    make: satellites.check_address(${address}, ${direction})
+    make: satellites.check_address(${address}, ${direction}, ${digicallsign})
 
 file_format: 1

--- a/grc/satellites_check_address.block.yml
+++ b/grc/satellites_check_address.block.yml
@@ -16,6 +16,7 @@ parameters:
 -   id: digicallsign
     label: Digicallsign
     dtype: string
+    default: ''
 
 inputs:
 -   domain: message

--- a/python/check_address.py
+++ b/python/check_address.py
@@ -17,7 +17,7 @@ import pmt
 
 class check_address(gr.basic_block):
     """docstring for block check_address"""
-    def __init__(self, address, direction, digicallsign):
+    def __init__(self, address, direction, digicallsign=''):
         gr.basic_block.__init__(
             self,
             name='check_address',

--- a/python/check_address.py
+++ b/python/check_address.py
@@ -17,7 +17,7 @@ import pmt
 
 class check_address(gr.basic_block):
     """docstring for block check_address"""
-    def __init__(self, address, direction):
+    def __init__(self, address, direction, digicallsign):
         gr.basic_block.__init__(
             self,
             name='check_address',
@@ -28,6 +28,7 @@ class check_address(gr.basic_block):
         self.callsign = a[0]
         self.ssid = int(a[1]) if len(a) > 1 else None
         self.direction = direction
+        self.digicallsign = digicallsign
 
         self.message_port_register_in(pmt.intern('in'))
         self.set_msg_handler(pmt.intern('in'), self.handle_msg)
@@ -52,14 +53,42 @@ class check_address(gr.basic_block):
         else:
             address = packet[7:14]
 
+        if len(packet) > 20:
+
+            hbit = packet[20] >> 7
+# digi callsign; and above: hbit  (most significant bit after digi callsign)
+# (set to 1 in case of digipeated message)
+            digi = [c >> 1 for c in packet[14:20]]
+
+# error handling
+            try:
+                digi = bytes(digi).decode('ascii').rstrip(' ')
+
+            except UnicodeDecodeError:
+                print("Not to ASCII convertable string detected.")
+
+# extension bit (least significant bit after sender callsign)
+# (set to 0 in case of digi callsign follows)
+        ebit = packet[13] & 0x01
+
         callsign = [c >> 1 for c in address[:6]]
-        callsign = bytes(callsign).decode('ascii').rstrip(' ')
+
+# error handling
+        try:
+            callsign = bytes(callsign).decode('ascii').rstrip(' ')
+
+        except UnicodeDecodeError:
+            print("Not to ASCII convertable string detected.")
+
         ssid = (address[6] >> 1) & 0x0f
 
-        if (callsign != self.callsign
-                or (self.ssid is not None and ssid != self.ssid)):
-            # Incorrect address
-            self.message_port_pub(pmt.intern('fail'), msg_pmt)
-        else:
-            # Correct address
+
+# altered if sentence
+        if ((callsign == self.callsign
+                and (ssid == self.ssid if self.ssid is not None else True))
+                or (ebit == 0 and hbit == 1 and digi == self.digicallsign)):
+            # match
             self.message_port_pub(pmt.intern('ok'), msg_pmt)
+        else:
+            # no match
+            self.message_port_pub(pmt.intern('fail'), msg_pmt)

--- a/python/check_address.py
+++ b/python/check_address.py
@@ -53,6 +53,7 @@ class check_address(gr.basic_block):
         else:
             address = packet[7:14]
 
+        hbit = 0
         if len(packet) > 20:
 
             hbit = packet[20] >> 7
@@ -60,12 +61,7 @@ class check_address(gr.basic_block):
 # (set to 1 in case of digipeated message)
             digi = [c >> 1 for c in packet[14:20]]
 
-# error handling
-            try:
-                digi = bytes(digi).decode('ascii').rstrip(' ')
-
-            except UnicodeDecodeError:
-                print("Not to ASCII convertable string detected.")
+            digi = bytes(digi).decode('ascii').rstrip(' ')
 
 # extension bit (least significant bit after sender callsign)
 # (set to 0 in case of digi callsign follows)
@@ -73,19 +69,13 @@ class check_address(gr.basic_block):
 
         callsign = [c >> 1 for c in address[:6]]
 
-# error handling
-        try:
-            callsign = bytes(callsign).decode('ascii').rstrip(' ')
-
-        except UnicodeDecodeError:
-            print("Not to ASCII convertable string detected.")
+        callsign = bytes(callsign).decode('ascii').rstrip(' ')
 
         ssid = (address[6] >> 1) & 0x0f
 
-
 # altered if sentence
         if ((callsign == self.callsign
-                and (ssid == self.ssid if self.ssid is not None else True))
+                and (self.ssid is None or ssid == self.ssid))
                 or (ebit == 0 and hbit == 1 and digi == self.digicallsign)):
             # match
             self.message_port_pub(pmt.intern('ok'), msg_pmt)


### PR DESCRIPTION
Adds check for digipeater callsign and hbit set.
In combination with 'telemetry forwarder' good to filter out decoded own frames during transmitting (near TCA).