### PR TITLE
main-3.9: Add vector stream IO Reed-Solomon encoder

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -50,6 +50,8 @@ install(FILES
     satellites_doppler_correction.block.yml
     satellites_encode_rs.block.yml
     satellites_encode_rs_ccsds.block.yml
+    satellites_encode_rs_ccsds_vector.block.yml
+    satellites_encode_rs_vector.block.yml
     satellites_eseo_line_decoder.block.yml
     satellites_eseo_packet_crop.block.yml
     satellites_fixedlen_tagger.block.yml

--- a/grc/satellites_encode_rs_ccsds_vector.block.yml
+++ b/grc/satellites_encode_rs_ccsds_vector.block.yml
@@ -1,0 +1,34 @@
+id: satellites_encode_rs_ccsds_vector
+label: CCSDS Reed-Solomon Encoder (vector)
+category: '[Satellites]/FEC'
+
+parameters:
+-   id: frame_size
+    label: Frame size
+    default: 223
+    dtype: int  
+-   id: basis
+    label: Basis
+    dtype: enum
+    options: ['False', 'True']
+    option_labels: [Conventional, Dual]
+-   id: interleave
+    label: Interleave depth
+    default: 1
+    dtype: int
+
+inputs:
+-   domain: stream
+    dtype: byte
+    vlen: ${ frame_size }
+
+outputs:
+-   domain: stream
+    dtype: byte
+    vlen: ${ 255 * interleave }
+
+templates:
+    imports: import satellites
+    make: satellites.encode_rs(${frame_size}, ${basis}, ${interleave})
+
+file_format: 1

--- a/grc/satellites_encode_rs_vector.block.yml
+++ b/grc/satellites_encode_rs_vector.block.yml
@@ -1,0 +1,49 @@
+id: satellites_encode_rs_vector
+label: Reed-Solomon Encoder (vector)
+category: '[Satellites]/FEC'
+
+parameters:
+-   id: frame_size
+    label: Frame size
+    default: 223
+    dtype: int
+-   id: nsym
+    label: Bits per symbol
+    default: 8
+    dtype: int
+-   id: gfpoly
+    label: Generator polynomial
+    default: 0x11d
+    dtype: int
+-   id: fcr
+    label: First consecutive root
+    default: 1
+    dtype: int
+-   id: prim
+    label: Primitive element
+    default: 1
+    dtype: int
+-   id: nroots
+    label: Number of roots
+    default: 1
+    dtype: int
+-   id: interleave
+    label: Interleave depth
+    default: 1
+    dtype: int
+
+inputs:
+-   domain: stream
+    dtype: byte
+    vlen: ${ frame_size }
+
+outputs:
+-   domain: stream
+    dtype: byte
+    vlen: ${ (2**nsym - 1) * interleave }
+
+templates:
+    imports: import satellites
+    make: satellites.encode_rs(${frame_size}, ${nsym}, ${gfpoly}, ${fcr}, ${prim}, ${nroots}, ${interleave})
+
+file_format: 1

--- a/include/satellites/encode_rs.h
+++ b/include/satellites/encode_rs.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2018,2020 Daniel Estevez <daniel@destevez.net>
+ * Copyright 2018,2020,2024 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of gr-satellites
  *
@@ -11,42 +11,70 @@
 #ifndef INCLUDED_SATELLITES_ENCODE_RS_H
 #define INCLUDED_SATELLITES_ENCODE_RS_H
 
-#include <gnuradio/block.h>
+#include <gnuradio/sync_block.h>
 #include <satellites/api.h>
 
 namespace gr {
 namespace satellites {
 
 /*!
- * \brief <+description of block+>
+ * \brief Reed-Solomon encoder
  * \ingroup satellites
  *
  */
-class SATELLITES_API encode_rs : virtual public gr::block
+class SATELLITES_API encode_rs : virtual public gr::sync_block
 {
 public:
     typedef std::shared_ptr<encode_rs> sptr;
 
     /*!
-     * \brief Return a shared_ptr to a new instance of satellites::encode_rs.
+     * \brief Constructs a CCSDS Reed Solomon encoder using PDU IO.
      *
-     * To avoid accidental use of raw pointers, satellites::encode_rs's
-     * constructor is in a private implementation
-     * class. satellites::encode_rs::make is the public interface for
-     * creating new instances.
+     * \param dual_basis Selects the dual or conventional basis.
+     * \param interleave Interleave depth.
      */
     static sptr make(bool dual_basis, int interleave = 1);
 
     /*!
-     * \brief Return a shared_ptr to a new instance of satellites::encode_rs.
+     * \brief Constructs a CCSDS Reed Solomon encoder using vector stream IO.
      *
-     * To avoid accidental use of raw pointers, satellites::encode_rs's
-     * constructor is in a private implementation
-     * class. satellites::encode_rs::make is the public interface for
-     * creating new instances.
+     * \param frame_size Input frame size.
+     * \param dual_basis Selects the dual or conventional basis.
+     * \param interleave Interleave depth.
+     */
+    static sptr make(int frame_size, bool dual_basis, int interleave = 1);
+
+    /*!
+     * \brief Constructs a generic Reed Solomon encoder using PDU IO.
+     *
+     * \param symsize Size of the finite field elements.
+     * \param gfpoly Polynomial defining the finite field.
+     * \param fcr First consecutive root of the Reed-Solomon generator polynomial.
+     * \param prim Primitive element used in the generator polynomial.
+     * \param nroots Number of roots of the generator polynomial.
+     * \param interleave Interleave depth.
      */
     static sptr
     make(int symsize, int gfpoly, int fcr, int prim, int nroots, int interleave = 1);
+
+    /*!
+     * \brief Constructs a generic Reed Solomon encoder using vector stream IO.
+     *
+     * \param frame_size Input frame size.
+     * \param symsize Size of the finite field elements.
+     * \param gfpoly Polynomial defining the finite field.
+     * \param fcr First consecutive root of the Reed-Solomon generator polynomial.
+     * \param prim Primitive element used in the generator polynomial.
+     * \param nroots Number of roots of the generator polynomial.
+     * \param interleave Interleave depth.
+     */
+    static sptr make(int frame_size,
+                     int symsize,
+                     int gfpoly,
+                     int fcr,
+                     int prim,
+                     int nroots,
+                     int interleave);
 };
 
 } // namespace satellites

--- a/lib/encode_rs_impl.cc
+++ b/lib/encode_rs_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2018,2020 Daniel Estevez <daniel@destevez.net>
+ * Copyright 2018,2020,2024 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of gr-satellites
  *
@@ -17,6 +17,7 @@
 
 #include <boost/format.hpp>
 #include <algorithm>
+#include <cstdint>
 #include <exception>
 
 extern "C" {
@@ -33,6 +34,11 @@ encode_rs::sptr encode_rs::make(bool dual_basis, int interleave)
     return gnuradio::make_block_sptr<encode_rs_impl>(dual_basis, interleave);
 }
 
+encode_rs::sptr encode_rs::make(int frame_size, bool dual_basis, int interleave)
+{
+    return gnuradio::make_block_sptr<encode_rs_impl>(frame_size, dual_basis, interleave);
+}
+
 encode_rs::sptr
 encode_rs::make(int symsize, int gfpoly, int fcr, int prim, int nroots, int interleave)
 {
@@ -40,13 +46,40 @@ encode_rs::make(int symsize, int gfpoly, int fcr, int prim, int nroots, int inte
         symsize, gfpoly, fcr, prim, nroots, interleave);
 }
 
-/*
- * The private constructor
- */
+encode_rs::sptr encode_rs::make(int frame_size,
+                                int symsize,
+                                int gfpoly,
+                                int fcr,
+                                int prim,
+                                int nroots,
+                                int interleave)
+{
+    return gnuradio::make_block_sptr<encode_rs_impl>(
+        frame_size, symsize, gfpoly, fcr, prim, nroots, interleave);
+}
+
 encode_rs_impl::encode_rs_impl(bool dual_basis, int interleave)
-    : gr::block(
+    : gr::sync_block(
           "encode_rs", gr::io_signature::make(0, 0, 0), gr::io_signature::make(0, 0, 0)),
-      d_interleave(interleave)
+      d_interleave(interleave),
+      d_frame_size(0)
+{
+    setup_ccsds(dual_basis);
+    set_message_ports();
+}
+
+encode_rs_impl::encode_rs_impl(int frame_size, bool dual_basis, int interleave)
+    : gr::sync_block("encode_rs",
+                     gr::io_signature::make(1, 1, frame_size),
+                     gr::io_signature::make(1, 1, d_ccsds_nn * interleave)),
+      d_interleave(interleave),
+      d_frame_size(frame_size)
+{
+    check_frame_size();
+    setup_ccsds(dual_basis);
+}
+
+void encode_rs_impl::setup_ccsds(bool dual_basis)
 {
     static constexpr int parity_offset = d_ccsds_nn - d_ccsds_nroots;
     if (dual_basis) {
@@ -60,17 +93,37 @@ encode_rs_impl::encode_rs_impl(bool dual_basis, int interleave)
     d_nroots = d_ccsds_nroots;
 
     check_interleave();
+}
+
+encode_rs_impl::encode_rs_impl(
+    int symsize, int gfpoly, int fcr, int prim, int nroots, int interleave)
+    : gr::sync_block(
+          "encode_rs", gr::io_signature::make(0, 0, 0), gr::io_signature::make(0, 0, 0)),
+      d_interleave(interleave),
+      d_frame_size(0)
+{
+    setup_generic(symsize, gfpoly, fcr, prim, nroots);
     set_message_ports();
 }
 
-/*
- * The private constructor
- */
-encode_rs_impl::encode_rs_impl(
-    int symsize, int gfpoly, int fcr, int prim, int nroots, int interleave)
-    : gr::block(
-          "encode_rs", gr::io_signature::make(0, 0, 0), gr::io_signature::make(0, 0, 0)),
-      d_interleave(interleave)
+encode_rs_impl::encode_rs_impl(int frame_size,
+                               int symsize,
+                               int gfpoly,
+                               int fcr,
+                               int prim,
+                               int nroots,
+                               int interleave)
+    : gr::sync_block("encode_rs",
+                     gr::io_signature::make(1, 1, frame_size),
+                     gr::io_signature::make(1, 1, ((1U << symsize) - 1) * interleave)),
+      d_interleave(interleave),
+      d_frame_size(frame_size)
+{
+    check_frame_size();
+    setup_generic(symsize, gfpoly, fcr, prim, nroots);
+}
+
+void encode_rs_impl::setup_generic(int symsize, int gfpoly, int fcr, int prim, int nroots)
 {
     d_rs_p = init_rs_char(symsize, gfpoly, fcr, prim, nroots, 0);
     const int codeword_size = (1U << symsize) - 1;
@@ -86,7 +139,6 @@ encode_rs_impl::encode_rs_impl(
     d_nroots = nroots;
 
     check_interleave();
-    set_message_ports();
 }
 
 void encode_rs_impl::check_interleave()
@@ -97,6 +149,13 @@ void encode_rs_impl::check_interleave()
     }
 }
 
+void encode_rs_impl::check_frame_size()
+{
+    if (d_frame_size % d_interleave != 0) {
+        throw std::runtime_error("Interleave must divide frame size");
+    }
+}
+
 void encode_rs_impl::set_message_ports()
 {
     message_port_register_out(pmt::mp("out"));
@@ -104,9 +163,6 @@ void encode_rs_impl::set_message_ports()
     set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->msg_handler(msg); });
 }
 
-/*
- * Our virtual destructor.
- */
 encode_rs_impl::~encode_rs_impl()
 {
     if (d_rs_p) {
@@ -114,14 +170,35 @@ encode_rs_impl::~encode_rs_impl()
     }
 }
 
-void encode_rs_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) {}
-
-int encode_rs_impl::general_work(int noutput_items,
-                                 gr_vector_int& ninput_items,
-                                 gr_vector_const_void_star& input_items,
-                                 gr_vector_void_star& output_items)
+int encode_rs_impl::work(int noutput_items,
+                         gr_vector_const_void_star& input_items,
+                         gr_vector_void_star& output_items)
 {
-    return 0;
+    auto in = static_cast<const uint8_t*>(input_items[0]);
+    auto out = static_cast<uint8_t*>(output_items[0]);
+
+    const auto rs_kk = d_frame_size / d_interleave;
+    const auto pad = d_rs_codeword.size() - rs_kk - d_nroots;
+    const auto output_frame_size = d_rs_codeword.size() * d_interleave;
+
+    for (int i = 0; i < noutput_items; ++i) {
+        for (int j = 0; j < d_interleave; ++j) {
+            std::fill(d_rs_codeword.begin(), d_rs_codeword.begin() + pad, 0);
+            for (int k = 0; k < rs_kk; ++k) {
+                d_rs_codeword[pad + k] = in[j + k * d_interleave];
+            }
+
+            d_encode_rs(d_rs_codeword.data());
+
+            for (int k = 0; k < rs_kk + d_nroots; ++k) {
+                out[j + k * d_interleave] = d_rs_codeword[pad + k];
+            }
+        }
+        in += d_frame_size;
+        out += output_frame_size;
+    }
+
+    return noutput_items;
 }
 
 void encode_rs_impl::msg_handler(pmt::pmt_t pmt_msg)

--- a/lib/encode_rs_impl.h
+++ b/lib/encode_rs_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2018,2020 Daniel Estevez <daniel@destevez.net>
+ * Copyright 2018,2020, 2024 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of gr-satellites
  *
@@ -28,28 +28,36 @@ private:
     std::vector<uint8_t> d_output_frame;
     int d_nroots;
     void* d_rs_p = NULL;
+    const int d_frame_size; // used only with vector stream IO
 
     std::function<void(uint8_t*)> d_encode_rs;
 
     constexpr static int d_ccsds_nn = 255;
     constexpr static int d_ccsds_nroots = 32;
 
+    void setup_ccsds(bool dual_basis);
+    void setup_generic(int symsize, int gfpoly, int fcr, int prim, int nroots);
     void check_interleave();
+    void check_frame_size();
     void set_message_ports();
 
 public:
     encode_rs_impl(bool dual_basis, int interleave = 1);
+    encode_rs_impl(int frame_size, bool dual_basis, int interleave = 1);
     encode_rs_impl(
         int symsize, int gfpoly, int fcr, int prim, int nroots, int interleave = 1);
-    ~encode_rs_impl();
+    encode_rs_impl(int frame_size,
+                   int symsize,
+                   int gfpoly,
+                   int fcr,
+                   int prim,
+                   int nroots,
+                   int interleave);
+    ~encode_rs_impl() override;
 
-    // Where all the action really happens
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
-
-    int general_work(int noutput_items,
-                     gr_vector_int& ninput_items,
-                     gr_vector_const_void_star& input_items,
-                     gr_vector_void_star& output_items);
+    int work(int noutput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items) override;
 
     void msg_handler(pmt::pmt_t pmt_msg);
 };

--- a/python/bindings/encode_rs_python.cc
+++ b/python/bindings/encode_rs_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(encode_rs.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(99021331d1740a77b5cd3f667010f815)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3086a7f214bce934affa48bc9d1c4fc5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -35,22 +35,31 @@ void bind_encode_rs(py::module& m)
 
     py::class_<encode_rs, gr::block, gr::basic_block, std::shared_ptr<encode_rs>>(
         m, "encode_rs", D(encode_rs))
-
         .def(py::init(py::overload_cast<bool, int>(&encode_rs::make)),
              py::arg("dual_basis"),
              py::arg("interleave") = 1,
              D(encode_rs, make))
-
-
+        .def(py::init(py::overload_cast<int, bool, int>(&encode_rs::make)),
+             py::arg("frame_size"),
+             py::arg("dual_basis"),
+             py::arg("interleave") = 1,
+             D(encode_rs, make))
         .def(py::init(py::overload_cast<int, int, int, int, int, int>(&encode_rs::make)),
              py::arg("symsize"),
              py::arg("gfpoly"),
              py::arg("fcr"),
              py::arg("prim"),
              py::arg("nroots"),
-             py::arg("interleave"),
+             py::arg("interleave") = 1,
              D(encode_rs, make))
-
-
-        ;
+        .def(py::init(
+                 py::overload_cast<int, int, int, int, int, int, int>(&encode_rs::make)),
+             py::arg("frame_size"),
+             py::arg("symsize"),
+             py::arg("gfpoly"),
+             py::arg("fcr"),
+             py::arg("prim"),
+             py::arg("nroots"),
+             py::arg("interleave"),
+             D(encode_rs, make));
 }


### PR DESCRIPTION
This modifies the encode_rs C++ block to add support for vector stream IO as an alternative to PDU IO. Stream IO can propagate backpressure to the source, so it is necessary to use stream IO instead of PDU IO when backpressure is needed.

(cherry picked from commit 8838359882814fbbed9c5283e53771366dd4e95e)