### PR TITLE
Create RUZAEVKA-390.yml

### DIFF
--- a/python/satyaml/RUZAEVKA-390.yml
+++ b/python/satyaml/RUZAEVKA-390.yml
@@ -1,0 +1,25 @@
+name: RUZAEVKA-390
+alternative_names:
+  - RS44S
+norad: 61766
+data:
+  &tlm AX25 telemetry:
+    telemetry: ax25
+transmitters:
+  1k135 AX25 AFSK downlink:
+    frequency: 437.050e+6
+    modulation: AFSK
+    baudrate: 1143
+    af_carrier: 1810
+    deviation: 565
+    framing: AX.25
+    data:
+    - *tlm
+  2k4 AX25 FSK downlink:
+    frequency: 435.750e+6
+    modulation: FSK
+    baudrate: 2400
+    deviation: 600
+    framing: AX.25
+    data:
+    - *tlm


### PR DESCRIPTION
Newly launched satellite. Decoded with the following obs: https://network.satnogs.org/observations/10731538/

```
-> Packet from 1k135 AX25 AFSK downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'ALL' (total 3)
                ssid = Container: 
                    ch = True
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'RS44S' (total 5)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = True
        control = 0x03
        pid = 0xF0
    info = b'RS44S S=8264 U1=4.67 U2=4.64 T1=19.71 Mx=13.231603 My=6.952198 Mz=35.209518 Vx=28.458015 Vy=-6.908397 Vz=31.068703 Time=557525154' (total 129)
```

This satellites also transmits SSTV

![image](https://github.com/user-attachments/assets/2b84fcea-9145-4113-91bc-3bb80c2a08d0)
