### PR TITLE
Create COLIBRI-S.yml

### DIFF
--- a/python/satyaml/COLIBRI-S.yml
+++ b/python/satyaml/COLIBRI-S.yml
@@ -1,0 +1,17 @@
+name: COLIBRI-S
+alternative_names:
+  - RS67S
+norad: 61746
+data:
+   &tlm Telemetry:
+     unknown
+transmitters:
+   9k6 FSK downlink:
+     frequency: 436.835e+6
+     modulation: FSK
+     baudrate: 9600
+     framing: GEOSCAN
+     deviation: 4800
+     frame size: 74
+     data:
+     - *tlm


### PR DESCRIPTION
The Yaml file is made based on an IQ recording and measured in the following way.

`gr_satellites COLIBRI-S.yml --rawint16 cut_tuned_iq_57600_10956048.wav --samp_rate 57600 --iq --disable_dc_block --dump_path .`

That produced the following output.

![image](https://github.com/user-attachments/assets/7d086f5c-216b-4522-a115-04fcafaed97f)
