### PR TITLE
crcs: Use digital.crc_check for GNU Radio >= 3.10

### DIFF
--- a/python/components/deframers/fossasat_deframer.py
+++ b/python/components/deframers/fossasat_deframer.py
@@ -15,7 +15,7 @@ import pmt
 from ... import pdu_head_tail
 from ... import sx12xx_packet_crop
 from ... import reflect_bytes
-from ... import crc_check
+from ...crcs import crc_check
 from ...hier.pn9_scrambler import pn9_scrambler
 from ...hier.sync_to_pdu_packed import sync_to_pdu_packed
 from ...utils.options_block import options_block

--- a/python/components/deframers/openlst_deframer.py
+++ b/python/components/deframers/openlst_deframer.py
@@ -11,7 +11,8 @@
 from gnuradio import gr, digital
 import pmt
 
-from ... import crc_check, pdu_head_tail
+from ... import pdu_head_tail
+from ...crcs import crc_check
 from ...hier.sync_to_pdu_packed import sync_to_pdu_packed
 from ...utils.options_block import options_block
 

--- a/python/crcs.py
+++ b/python/crcs.py
@@ -8,7 +8,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-from . import crc_check
+from gnuradio import gr
+
+api_version = int(gr.api_version())
+minor_version = int(gr.minor_version())
+
+if api_version <= 3 and minor_version < 2:
+    from . import crc_check
+else:
+    from gnuradio.digital import crc_check
 
 
 def crc16_arc(swap_endianness=True, discard_crc=True):


### PR DESCRIPTION
Pleasant side-effect: The upstreamed block is less verbose and does not print to stdout/stderr by default.