### PR TITLE
Update check_address.py

### DIFF
--- a/python/check_address.py
+++ b/python/check_address.py
@@ -24,7 +24,7 @@ class check_address(gr.basic_block):
             in_sig=[],
             out_sig=[])
 
-        a = address.split('-')
+        a = address.rsplit('-', 1)
         self.callsign = a[0]
         self.ssid = int(a[1]) if len(a) > 1 else None
         self.direction = direction


### PR DESCRIPTION
TEVEL2 sender callsigns (example: TVL2-3-1) using one "-" within the callsign showed that check_address.py splitted on every "-" instead on the last.

Changing line 27 from 'split' to "rsplit' solves the problem.