### PR TITLE
Switch to cmake 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.8)
 project(gr-satellites CXX C)
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 project(gr-satellites CXX C)
 enable_testing()
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -95,11 +95,11 @@ inside the directory containing the gr-satellites sources:
 
 .. code-block:: console
 
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ make
-   $ sudo make install
+   $ git clone https://github.com/daniestevez/gr-satellites
+   $ cd gr-satellites/
+   $ cmake -S . -B build
+   $ cmake --build build --parallel
+   $ cmake --install build
    $ sudo ldconfig
 
 After running ``make``, you can run the tests by doing ``make test`` in the

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -95,14 +95,12 @@ inside the directory containing the gr-satellites sources:
 
 .. code-block:: console
 
-   $ git clone https://github.com/daniestevez/gr-satellites
-   $ cd gr-satellites/
    $ cmake -S . -B build
    $ cmake --build build --parallel
-   $ cmake --install build
+   $ sudo cmake --install build
    $ sudo ldconfig
 
-After running ``make``, you can run the tests by doing ``make test`` in the
+After build stage, you can run the tests by doing ``make test`` in the
 ``build/`` directory.
 
 .. note::


### PR DESCRIPTION
stop to use make because since CMake 3.15 (Ubuntu 20.04), Generator can be set in env CMAKE_GENERATOR and sometimes it is not the Unix Makefiles; Tested in Ubuntu 24
P.S. Also you can install to non-system folder, see example https://askubuntu.com/a/1543849/1087530