### PR TITLE
Update and rename NUSHSat1.yml to NUSHSAT-1.yml

### DIFF
--- a/python/satyaml/NUSHSAT-1.yml
+++ b/python/satyaml/NUSHSAT-1.yml
@@ -1,13 +1,16 @@
-name: NUSHSat1
-norad: 98628
+name: NUSHSAT-1
+norad: 63211
+telemetry_servers:
+  - SIDS https://sat.nushigh.school/telemetry
 data:
-  &tlm Unknown telemetry:
-    unknown
+  &tlm CSP telemetry:
+    telemetry: csp
 transmitters:
   1k2 FSK AX100 ASM+Golay downlink:
     frequency: 436.200e+6
     modulation: FSK
     baudrate: 1200
+    deviation: 575
     framing: AX100 ASM+Golay
     data:
     - *tlm
@@ -22,13 +25,6 @@ transmitters:
     frequency: 436.200e+6
     modulation: FSK
     baudrate: 4800
-    framing: AX100 ASM+Golay
-    data:
-    - *tlm
-  9k6 FSK AX100 ASM+Golay downlink:
-    frequency: 436.200e+6
-    modulation: FSK
-    baudrate: 9600
     framing: AX100 ASM+Golay
     data:
     - *tlm


### PR DESCRIPTION
This satellites is identified as object 63211.
Measurements show that the deviation at 1200 baud is 575, future baud rates may be increased to 4k8 maximum when they want to test there payload.

The team has enabled a SIDS collection server.

![image](https://github.com/user-attachments/assets/967c00f9-6a85-434d-a079-499c5f6f0458)
