### PR TITLE
Replace list and tuple by List and Tuple in type annotations

### DIFF
--- a/python/mobitex_fec.py
+++ b/python/mobitex_fec.py
@@ -31,6 +31,8 @@ References:
 import sys
 
 from enum import IntEnum
+from typing import Tuple
+
 
 # Matrix H, in 8 and 12 column variant
 FEC_MATRIX_8b = [
@@ -163,7 +165,7 @@ def decode(codeword: int):
     return message, fec, Status.ERROR_CORRECTED
 
 
-def split(word: int) -> tuple[int, int]:
+def split(word: int) -> Tuple[int, int]:
     """Split 12-bit codeword into data byte and FEC."""
     return (word >> 4), (word & 0xF)
 
@@ -176,7 +178,7 @@ def pack_2b(byte0: int, byte1: int) -> bytes:
     return bytes([encoded_byte1, encoded_byte2, encoded_byte3])
 
 
-def unpack_2b(code: bytes) -> tuple[int, int]:
+def unpack_2b(code: bytes) -> Tuple[int, int]:
     """From three bytes unpack two 12-bit codewords."""
     codeword0 = (code[0] << 4) | (code[1] >> 4)
     codeword1 = ((code[1] & 0x0F) << 8) | code[2]

--- a/python/mobitex_to_datablocks.py
+++ b/python/mobitex_to_datablocks.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import itertools
 
@@ -22,7 +22,7 @@ from .mobitex_fec import decode, encode, Status
 
 
 def decode_control(control0: int, control1: int, fec: int) -> \
-        Optional[tuple[list[int], int]]:
+        Optional[Tuple[List[int], int]]:
     """
     Process control bytes and FEC byte, correcting errors if possible.
     Returns error-corrected bytes and error count, or None if uncorrectable.
@@ -70,7 +70,7 @@ def decode_unknown_callsign(
     callsign: bytes,
     crc: bytes,
     max_bit_flips: int,
-) -> Optional[tuple[bytes, bytes, int]]:
+) -> Optional[Tuple[bytes, bytes, int]]:
     """Error-corrects callsign+crc by flipping bits until CRC matches or
     maximum number of bit-flips is exceeded.
 
@@ -121,7 +121,7 @@ def compare_expected_callsign(
     callsign: bytes,
     crc: bytes,
     callsign_ref: bytes,
-) -> tuple[bytes, int]:
+) -> Tuple[bytes, int]:
     """
     Calculates bit errors between received callsign+CRC and expected
     reference callsign+CRC.


### PR DESCRIPTION
list and tuple are not supported as a type annotations in older versions of Python (e.g., Python 3.8). Instead, List and Tuple from the typing module should be used.

(cherry picked from commit 29f8feeb26f4c146681e109df8f72afdb5f80c9b)