### PR TITLE
Remove empty parameters in Message Counter GRC file

### DIFF
--- a/grc/satellites_message_counter.block.yml
+++ b/grc/satellites_message_counter.block.yml
@@ -6,8 +6,6 @@ templates:
   imports: import satellites
   make: satellites.message_counter()
 
-parameters:
-
 inputs:
 - id: in
   domain: message


### PR DESCRIPTION
This fixes an error printed by gnuradio-companion.