### PR TITLE
Replace WS-1's temporary NORAD ID by the definitive one

### DIFF
--- a/python/satyaml/WS-1.yml
+++ b/python/satyaml/WS-1.yml
@@ -1,7 +1,7 @@
 name: WS-1
 alternative_names: 
   - Waratah Seed-1
-norad: 98849
+norad: 60469
 data:
   &tlm Telemetry:
     telemetry: ax25


### PR DESCRIPTION
This pull request to update the NORAD ID of WS-1 to 60469 according to [SatNOGS](https://db.satnogs.org/satellite/FQIY-5061-3565-2438-4414) and [CelesTrak](https://celestrak.org/satcat/table-satcat.php?CATNR=60469&PAYLOAD=1&ACTIVE=1&ORBIT=1&MAX=500)