### PR TITLE
Mobitex: Drop frame if none of the datablocks is correct

### DIFF
--- a/python/tubix20_reframer.py
+++ b/python/tubix20_reframer.py
@@ -148,14 +148,18 @@ class tubix20_reframer(gr.basic_block):
         return packet_out
 
     def publish_frame(self):
-        packet_out = self.prepare_frame()
-
         num_blocks_correct = sum(
             [1 for tags in self.tags.values() if tags['crc_valid']])
         num_corrected_errors = sum(
             [tags['corrected_errors'] for tags in self.tags.values()])
         num_uncorrected_errors = sum(
             [tags['uncorrected_errors'] for tags in self.tags.values()])
+
+        # Only forward frames with at least one correct datablock
+        if num_blocks_correct < 1:
+            return
+
+        packet_out = self.prepare_frame()
 
         meta = pmt.dict_add(
             self.block0_meta,


### PR DESCRIPTION
Using gr-satellites to receive BEESAT-1 leads to many false positive frames (up to a few hundred per pass - even without any transmission happening). Normally the Mobitex deframer drops false positive frames by checking the callsign & callsign-crc for bit errors - unfortunately specifically for BEESAT-1 this is not possible since the callsign is placed before the syncword and thus unavailable to the deframer.

With this patch, frames have to contain of at least one correct datablock, otherwise they are dropped.