### PR TITLE
Add support for HUNITY

### DIFF
--- a/python/satyaml/HUNITY.yml
+++ b/python/satyaml/HUNITY.yml
@@ -1,0 +1,44 @@
+name: HUNITY
+norad: 98537
+data:
+  &tlm Telemetry:
+    unknown
+  &signalling Signalling:
+    unknown
+transmitters:
+  1k25 FSK:
+    frequency: 437.390e+6
+    modulation: FSK
+    baudrate: 1250
+    deviation: 312.5
+    framing: MRC-100 RA
+    frame size: 126
+    data:
+    - *tlm
+  2k5 FSK:
+    frequency: 437.390e+6
+    modulation: FSK
+    baudrate: 2500
+    deviation: 625
+    framing: MRC-100 RA
+    frame size: 126
+    data:
+    - *tlm
+  5k FSK:
+    frequency: 437.390e+6
+    modulation: FSK
+    baudrate: 5000
+    deviation: 1250
+    framing: MRC-100 RA
+    frame size: 126
+    data:
+    - *tlm
+  12k5 FSK:
+    frequency: 437.390e+6
+    modulation: FSK
+    baudrate: 12500
+    deviation: 3125
+    framing: MRC-100 RA
+    frame size: 126
+    data:
+    - *tlm


### PR DESCRIPTION
SatYAML file based on the one shared here
https://community.libre.space/t/transporter-15-rideshare-vsfb-slc-4e-28-november-2025-1830-utc/13951/162

Decoder tested with the file shared in
https://community.libre.space/t/decoding-hunity/14124/3

The telemetry server has been removed because I get the following error:

could not connect to wss://gnd.bme.hu:8070/send; disabling telemetry submission

It appears that this telemetry server is no longer running, so it does not make sense to have it in the SatYAML file.