### PR TITLE
Add SAKHACUBE-CHOLBON

### DIFF
--- a/python/satyaml/SAKHACUBE-CHOLBON.yml
+++ b/python/satyaml/SAKHACUBE-CHOLBON.yml
@@ -1,0 +1,31 @@
+name: SAKHACUBE-CHOLBON
+alternative_names:
+  - RS18S
+  - Чолбон
+norad: 67290
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  2k4 FSK downlink:
+    frequency: 437.350e+6
+    modulation: FSK
+    baudrate: 2400
+    framing: USP
+    data:
+    - *tlm
+  4k8 FSK downlink:
+    frequency: 437.350e+6
+    modulation: FSK
+    baudrate: 4800
+    framing: USP
+    data:
+    - *tlm
+  9k6 FSK downlink:
+    frequency: 437.350e+6
+    modulation: FSK
+    baudrate: 9600
+    framing: USP
+    data:
+    - *tlm
+


### PR DESCRIPTION
YAML pulled from sonik.space. Same launch and bus as Luca and QMR-KWT 2, regular Sputnix USP.
SatNOGS: [https://db.satnogs.org/satellite/CPWN-2484-4785-1722-0154](https://db.satnogs.org/satellite/CPWN-2484-4785-1722-0154), IARU:[https://iaru.amsat-uk.org/finished_detail.php?serialnum=1047](https://iaru.amsat-uk.org/finished_detail.php?serialnum=1047), note that 4800bps USP is not listed in transmitters, but may occasionally be used. 19200 USP will be limited to passes over our ground station.
Some time later we will be testing 1200bps AX.25 G3RUH and SSTV, not sure how (and when) to add them, though.