### PR TITLE
Add support for QMR-KWT 2

### DIFF
--- a/python/satyaml/QMR-KWT-2.yml
+++ b/python/satyaml/QMR-KWT-2.yml
@@ -1,0 +1,22 @@
+name: QMR-KWT-2
+alternative_names:
+  - RS95S
+norad: 98448
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  2k4 FSK USP downlink:
+    frequency: 436.9500e+6
+    modulation: FSK
+    baudrate: 2400
+    framing: USP
+    data:
+    - *tlm
+  9k6 FSK USP downlink:
+    frequency: 436.9500e+6
+    modulation: FSK
+    baudrate: 9600
+    framing: USP
+    data:
+    - *tlm


### PR DESCRIPTION
This pull request add the support for QMR-KWT 2

There are 2 transmitters, because at the beginning the sat was transmitting at [2k4](https://network.satnogs.org/observations/13273585/) bauds and changed recently to [9k6](https://network.satnogs.org/observations/13489333/). I kept 2k4 just in case, if the team decide to switch back to it again.

Here is a test of decoding signals at 9k6 bauds using the wav file from this [observation](https://network.satnogs.org/observations/13489333) :

```
run command : gr_satellites 98448 --wavfile out.wav --samp_rate 48e3 --start_time 2026-02-28T10:19:45 --throttle

-> Packet from 9k6 FSK USP downlink
Container:
    header = Container:
        addresses = ListContainer:
            Container:
                callsign = u'R2ANF' (total 5)
                ssid = Container:
                    ch = False
                    ssid = 0
                    extension = False
            Container:
                callsign = u'RS95S' (total 5)
                ssid = Container:
                    ch = False
                    ssid = 1
                    extension = True
        control = 0x00
        pid = 0xF0
    info = b'FB\x02\x00\x01\x00\x19\x00\xfd\x00\xffr\x1e\x12\x00\x0e^\x1f\xa2i\n\xa0\x02\x00\x80%\x00\x00*\x00\xa0\x1e\x01!\xed\x04\x00\x01\x000\x004\x05g\x05.\x05N\x04I\x04\x9d\x04\x0f\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00E\xfe\xda\xfd\x06\xfe\xfa\xfd\x00@\x00\x00\xb0\x1e\xbd\xa0\x02\x00P\x98\x97Z\x9a\x04' (total 89)
-> Packet from 9k6 FSK USP downlink
Container:
    header = Container:
        addresses = ListContainer:
            Container:
                callsign = u'R2ANF' (total 5)
                ssid = Container:
                    ch = False
                    ssid = 0
                    extension = False
            Container:
                callsign = u'RS95S' (total 5)
                ssid = Container:
                    ch = False
                    ssid = 1
                    extension = True
        control = 0x00
        pid = 0xF0
    info = b'FB\x02\x00\x01\x00\x19\x00\xfd\x00\xffx\x1e\x12\x00\x0e|\x1f\xa2i(\xa0\x02\x00\x80%\x00\x00*\x00\xa0\x1e\x01!\xed\x04\x00\x01\x000\x00\xb0\x05\xa5\x05Q\x05\xc8\x04\xc3\x04\xda\x04\x14\x00\x00\x001\x00\x00\x00\x00\x00\x00\x00Q\xfe\xf3\xfd%\xfe\x0c\xfe\x00@\x00\x00\xb0\x1e\xdb\xa0\x02\x00n\x98\x97Z\x9a\x04' (total 89)

```