### PR TITLE
Fix packet truncation bug in U482C Encode block

### DIFF
--- a/lib/u482c_encode_impl.cc
+++ b/lib/u482c_encode_impl.cc
@@ -116,11 +116,11 @@ void u482c_encode_impl::msg_handler(const pmt::pmt_t& pmt_msg)
     }
 
     // Send via GNU Radio message
-    message_port_pub(
-        pmt::mp("out"),
-        pmt::cons(
-            pmt::PMT_NIL,
-            pmt::init_u8vector(d_preamble_len + k_header_len + payload_len, &d_data[0])));
+    message_port_pub(pmt::mp("out"),
+                     pmt::cons(pmt::PMT_NIL,
+                               pmt::init_u8vector(d_preamble_len + k_syncword_len +
+                                                      k_header_len + payload_len,
+                                                  &d_data[0])));
 }
 } /* namespace satellites */
 } /* namespace gr */


### PR DESCRIPTION
This fixes a packet truncation bug in the U482C Encode block that happened because the calculation of the output PDU length did not take into account the syncword length, so the output PDU was always 4 bytes too short. The bug and the fix was reported in #811.