### PR TITLE
Add ISS Zarya APRS

### DIFF
--- a/python/satyaml/ISS.yml
+++ b/python/satyaml/ISS.yml
@@ -1,0 +1,19 @@
+name: ISS
+alternative_names:
+  - ZARYA
+  - RS0ISS
+  - NA1SS
+norad: 25544
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  1k2 AFSK downlink:
+    frequency:  437.825e+6
+    modulation: AFSK
+    baudrate: 1200
+    af_carrier: 1700
+    deviation: 600
+    framing: AX.25
+    data:
+    - *tlm

--- a/python/satyaml/LAPAN-A2.yml
+++ b/python/satyaml/LAPAN-A2.yml
@@ -1,0 +1,19 @@
+name: LAPAN-A2
+alternative_names:
+  - IO-86
+  - ORARI
+  - YBOX
+norad: 40931
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  1k2 AFSK downlink:
+    frequency:  145.825e+6
+    modulation: AFSK
+    baudrate: 1200
+    af_carrier: 1700
+    deviation: 300
+    framing: AX.25
+    data:
+    - *tlm


### PR DESCRIPTION
from this observation: [https://network.satnogs.org/observations/14155241/](https://network.satnogs.org/observations/14155241/) :

```
gr_satellites ISS.yml --wavfile /tmp/satnogs_14155241_2026-05-26T03-03-03.ogg 

-> Packet from 1k2 AFSK downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'0P0PS2' (total 6)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'RS0ISS' (total 6)
                ssid = Container: 
                    ch = True
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'APRSAT' (total 6)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = True
        control = 0x03
        pid = 0xF0
    info = b"'v&\x1cl \x1cSI]ARISS-International Space Station=\r" (total 45)
```
