### PR TITLE
Make viterbi.c implementation re-entrant

### DIFF
--- a/lib/u482c_decode_impl.cc
+++ b/lib/u482c_decode_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2016,2020 Daniel Estevez <daniel@destevez.net>
+ * Copyright 2016,2020,2026 Daniel Estevez <daniel@destevez.net>
  *
  * This file is part of gr-satellites
  *
@@ -56,8 +56,7 @@ u482c_decode_impl::u482c_decode_impl(bool verbose, int viterbi, int scrambler, i
     // init FEC
     if (d_viterbi != OFF) {
         int16_t polys[2] = { V27POLYA, V27POLYB };
-        set_viterbi_polynomial_packed(polys);
-        d_vp = create_viterbi_packed(d_rs_len * 8);
+        d_vp = create_viterbi_packed(d_rs_len * 8, polys);
         if (!d_vp)
             throw std::bad_alloc();
     }

--- a/lib/viterbi.c
+++ b/lib/viterbi.c
@@ -1,6 +1,7 @@
 /*
  * K=7 r=1/2 Viterbi decoder in portable C
  * Copyright Feb 2004, Phil Karn, KA9Q
+ * Copyright 2026 Daniel Estevez <daniel@destevez.net>
  * May be used under the terms of the GNU Lesser General Public License (LGPL)
  */
 
@@ -40,14 +41,6 @@ typedef union {
     uint8_t c[32];
 } branchtab_t;
 
-/* We use the CCSDS convention
- * (see CCSDS 131.0-B-2 TM Synchronization and Channel Coding p3-2) */
-static int16_t polys[2] = { V27POLYB, -V27POLYA };
-static bool init = false;
-
-static uint8_t partab[256];
-static bool p_init;
-
 /* State info for Viterbi decoder instance */
 struct v27 {
     metric_t metrics1; /* path metric buffer 1 */
@@ -57,14 +50,12 @@ struct v27 {
         *new_metrics;      /* Pointers to path metrics, swapped on every bit */
     decision_t* decisions; /* Beginning of decisions for block */
     uint16_t dlen;         /* Length of decisions array for block */
+    uint8_t partab[256];
+    branchtab_t branchtab[2];
 };
 
-static branchtab_t branchtab[2];
-static struct v27 v27_local;
-static decision_t decisions_local;
-
 /* Create 256-entry odd-parity lookup table */
-static void partab_init(void)
+static void partab_init(uint8_t partab[256])
 {
     int i, cnt, ti;
 
@@ -79,28 +70,15 @@ static void partab_init(void)
         }
         partab[i] = cnt & 1;
     }
-
-    p_init = true;
 }
 
-static inline int parityb(unsigned char x)
-{
-    extern uint8_t partab[256];
-    extern bool p_init;
-
-    if (!p_init)
-        partab_init();
-
-    return partab[x];
-}
-
-static inline int parity(uint32_t x)
+static inline int parity(uint32_t x, const uint8_t partab[256])
 {
     /* Fold down to one byte */
     x ^= (x >> 16);
     x ^= (x >> 8);
 
-    return parityb(x);
+    return partab[x];
 }
 
 /* Initialize Viterbi decoder for start of new frame */
@@ -123,28 +101,30 @@ int init_viterbi_packed(void* p, int starting_state)
     return 0;
 }
 
-void set_viterbi_polynomial_packed(int16_t polys[2])
+static void set_viterbi_polynomial_packed(const int16_t polys[2],
+                                          branchtab_t branchtab[2],
+                                          const uint8_t partab[256])
 {
     int state;
 
     for (state = 0; state < 32; state++) {
         branchtab[0].c[state] =
-            (polys[0] < 0) ^ parity((2 * state) & abs(polys[0])) ? 1 : 0;
+            (polys[0] < 0) ^ parity((2 * state) & abs(polys[0]), partab) ? 1 : 0;
         branchtab[1].c[state] =
-            (polys[1] < 0) ^ parity((2 * state) & abs(polys[1])) ? 1 : 0;
+            (polys[1] < 0) ^ parity((2 * state) & abs(polys[1]), partab) ? 1 : 0;
     }
-
-    init = true;
 }
 
 /* Create a new instance of a Viterbi decoder */
-void* create_viterbi_packed(int16_t len)
+void* create_viterbi_packed(int16_t len, const int16_t polys[2])
 {
     /* Keep state in internal RAM */
-    struct v27* vp = &v27_local;
+    struct v27* vp = (struct v27*)malloc(sizeof(struct v27));
+    if (vp == NULL)
+        return NULL;
 
-    if (!init)
-        set_viterbi_polynomial_packed(polys);
+    partab_init(vp->partab);
+    set_viterbi_polynomial_packed(polys, vp->branchtab, vp->partab);
 
     vp->dlen = (len + 6) * sizeof(decision_t);
     if ((vp->decisions = malloc(vp->dlen)) == NULL)
@@ -196,24 +176,26 @@ void delete_viterbi_packed(void* p)
 
     if (vp->decisions != NULL)
         free((void*)vp->decisions);
+
+    free(vp);
 }
 
 /* C-language butterfly */
-#define BFLY(b)                                                           \
-    do {                                                                  \
-        metric = (branchtab[0].c[b] ^ sym0) + (branchtab[1].c[b] ^ sym1); \
-                                                                          \
-        m0 = vp->old_metrics->w[b] + metric;                              \
-        m1 = vp->old_metrics->w[b + 32] + (2 - metric);                   \
-        decision = m0 > m1;                                               \
-        vp->new_metrics->w[(b << 1)] = decision ? m1 : m0;                \
-        d->w[b >> 2] |= decision << (((b << 1)) & 7);                     \
-                                                                          \
-        m0 -= (metric + metric - 2);                                      \
-        m1 += (metric + metric - 2);                                      \
-        decision = m0 > m1;                                               \
-        vp->new_metrics->w[(b << 1) + 1] = decision ? m1 : m0;            \
-        d->w[b >> 2] |= decision << (((b << 1) + 1) & 7);                 \
+#define BFLY(b)                                                                   \
+    do {                                                                          \
+        metric = (vp->branchtab[0].c[b] ^ sym0) + (vp->branchtab[1].c[b] ^ sym1); \
+                                                                                  \
+        m0 = vp->old_metrics->w[b] + metric;                                      \
+        m1 = vp->old_metrics->w[b + 32] + (2 - metric);                           \
+        decision = m0 > m1;                                                       \
+        vp->new_metrics->w[(b << 1)] = decision ? m1 : m0;                        \
+        d.w[b >> 2] |= decision << (((b << 1)) & 7);                              \
+                                                                                  \
+        m0 -= (metric + metric - 2);                                              \
+        m1 += (metric + metric - 2);                                              \
+        decision = m0 > m1;                                                       \
+        vp->new_metrics->w[(b << 1) + 1] = decision ? m1 : m0;                    \
+        d.w[b >> 2] |= decision << (((b << 1) + 1) & 7);                          \
     } while (0)
 
 /*
@@ -221,11 +203,12 @@ void delete_viterbi_packed(void* p)
  * Note that nbits is the number of decoded data bits, not the number
  * of symbols!
  */
-int update_viterbi_packed(void* p, uint8_t* syms, uint16_t nbits)
+int update_viterbi_packed(void* p, const uint8_t* syms, uint16_t nbits)
 {
     struct v27* vp = p;
     void* tmp;
-    decision_t *dp, *d = &decisions_local;
+    decision_t* dp;
+    decision_t d;
     uint16_t i = 0;
     uint8_t m0, m1, decision, metric, sym0, sym1;
 
@@ -236,7 +219,7 @@ int update_viterbi_packed(void* p, uint8_t* syms, uint16_t nbits)
 
     while (likely(nbits--)) {
         /* Cache decisions in internal memory */
-        memset(d, 0, sizeof(decision_t));
+        memset(&d, 0, sizeof(decision_t));
 
         /* Read symbols */
         sym0 = get_bit(syms, i);
@@ -278,7 +261,7 @@ int update_viterbi_packed(void* p, uint8_t* syms, uint16_t nbits)
         BFLY(31);
 
         /* Writeback cached data */
-        memcpy(dp++, d, sizeof(decision_t));
+        memcpy(dp++, &d, sizeof(decision_t));
 
         /* Swap pointers to old and new metrics */
         tmp = vp->old_metrics;
@@ -286,24 +269,31 @@ int update_viterbi_packed(void* p, uint8_t* syms, uint16_t nbits)
         vp->new_metrics = tmp;
     }
 
-    vp->dp = d;
+    vp->dp = dp - 1;
+
     return 0;
 }
 
-void encode_viterbi_packed(unsigned char* channel, unsigned char* data, int framebits)
+void encode_viterbi_packed(unsigned char* channel,
+                           const unsigned char* data,
+                           int framebits,
+                           const int16_t polys[2])
 {
     int i;
     unsigned char bit;
     unsigned char in_sr = 0;
     unsigned char out_sr = 0;
     unsigned char temp[256];
+    uint8_t partab[256];
+
+    partab_init(partab);
 
     for (i = 0; i < framebits + 8; i++) {
         bit = (i >= framebits) ? 0 : get_bit(data, i);
 
         in_sr = (in_sr << 1) | bit;
-        out_sr = (out_sr << 1) | ((polys[0] < 0) ^ parity(in_sr & abs(polys[0])));
-        out_sr = (out_sr << 1) | ((polys[1] < 0) ^ parity(in_sr & abs(polys[1])));
+        out_sr = (out_sr << 1) | ((polys[0] < 0) ^ parity(in_sr & abs(polys[0]), partab));
+        out_sr = (out_sr << 1) | ((polys[1] < 0) ^ parity(in_sr & abs(polys[1]), partab));
         temp[i >> 2] = out_sr;
     }
 

--- a/lib/viterbi.h
+++ b/lib/viterbi.h
@@ -20,15 +20,17 @@
 #define V27POLYA 0x6d
 #define V27POLYB 0x4f
 
-void* create_viterbi_packed(int16_t len);
+void* create_viterbi_packed(int16_t len, const int16_t polys[2]);
 int init_viterbi_packed(void* vp, int starting_state);
-int update_viterbi_packed(void* vp, unsigned char sym[], uint16_t npairs);
+int update_viterbi_packed(void* vp, const unsigned char sym[], uint16_t npairs);
 int chainback_viterbi_packed(void* vp,
                              unsigned char* data,
                              unsigned int nbits,
                              unsigned int endstate);
 void delete_viterbi_packed(void* vp);
-void encode_viterbi_packed(unsigned char* channel, unsigned char* data, int framebits);
-void set_viterbi_polynomial_packed(int16_t polys[2]);
+void encode_viterbi_packed(unsigned char* channel,
+                           const unsigned char* data,
+                           int framebits,
+                           const int16_t polys[2]);
 
 #endif // VITERBI_H_


### PR DESCRIPTION
The Viterbi decoder implementation in lib/viterbi.c is not re-entrant because it uses static variables to store decisions (which depend on the message being decoded), the branch table (which depends on the polynomials used), and the parity table (which is actually constant once it is initialized). Since viterbi.c is used in the u482c_decode block, this causes problems if there are multiple instances of this block in a flowgraph.

This makes the implementation re-entrant by moving all these static variables into the v27 struct. Even the parity table is moved into the struct for simplicity, since initializing a shared parity table correctly would require mutexes or atomic variables.

Additionally, I have added const qualifiers in array/pointer function arguments that can and should be const.

I have tested these changes by running gr_satellites on the AU02 recording in satellite-recordings and checking that I get a valid decode. This satellite uses an U482C radio with convolutional coding enabled.