### PR TITLE
Add length checks in packet cropping

### DIFF
--- a/python/cc11xx_packet_crop.py
+++ b/python/cc11xx_packet_crop.py
@@ -37,6 +37,11 @@ class cc11xx_packet_crop(gr.basic_block):
 
         crc_len = 2 if self.crc16 else 0
         packet_length = packet[0] + 1 + crc_len
+        if packet_length > len(packet):
+            print(
+                f'packet length {packet_length} greater than '
+                f'PDU size {len(packet)}; dropping')
+            return
 
         self.message_port_pub(
             pmt.intern('out'),

--- a/python/components/deframers/aalto1_deframer.py
+++ b/python/components/deframers/aalto1_deframer.py
@@ -49,7 +49,7 @@ class aalto1_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
-            packlen=255, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.scrambler = pn9_scrambler()
         self.crop = cc11xx_packet_crop(True)
         self.crc = crc16_ccitt_x25()

--- a/python/components/deframers/binar1_deframer.py
+++ b/python/components/deframers/binar1_deframer.py
@@ -53,7 +53,7 @@ class binar1_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
-            packlen=255+3, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.crop = cc11xx_packet_crop(use_crc16=True)
         self.crc = crc16_ccitt_false()
 

--- a/python/components/deframers/binar2_deframer.py
+++ b/python/components/deframers/binar2_deframer.py
@@ -47,7 +47,7 @@ class binar2_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.sync = sync_to_pdu_packed(
-            packlen=250, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.crop = sx12xx_packet_crop(crc_len=2)
         self.crc = crc16_cc11xx()
         self.remove_length = pdu_head_tail(3, 1)

--- a/python/components/deframers/endurosat_deframer.py
+++ b/python/components/deframers/endurosat_deframer.py
@@ -54,7 +54,7 @@ class endurosat_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
-            packlen=131, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.crop = cc11xx_packet_crop(use_crc16=True)
         self.crc = crc16_ccitt_false()
 

--- a/python/components/deframers/fossasat_deframer.py
+++ b/python/components/deframers/fossasat_deframer.py
@@ -53,7 +53,7 @@ class fossasat_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.sync = sync_to_pdu_packed(
-            packlen=255, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.reflect_1 = reflect_bytes()
         self.scrambler = pn9_scrambler()
         self.reflect_2 = reflect_bytes()

--- a/python/components/deframers/grizu263a_deframer.py
+++ b/python/components/deframers/grizu263a_deframer.py
@@ -53,7 +53,7 @@ class grizu263a_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.sync = sync_to_pdu_packed(
-            packlen=255, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.reflect_1 = reflect_bytes()
 
         # The scrambler is like the PN9, but uses 0x100 instead of 0x1FF

--- a/python/components/deframers/reaktor_hello_world_deframer.py
+++ b/python/components/deframers/reaktor_hello_world_deframer.py
@@ -63,7 +63,7 @@ class reaktor_hello_world_deframer(gr.hier_block2, options_block):
 
         self.slicer = digital.binary_slicer_fb()
         self.deframer = sync_to_pdu_packed(
-            packlen=255, sync=_syncword, threshold=syncword_threshold)
+            packlen=258, sync=_syncword, threshold=syncword_threshold)
         self.scrambler = pn9_scrambler()
         self.crop = cc11xx_packet_crop(True)
         self.crc = crc16_cc11xx()

--- a/python/components/deframers/spino_deframer.py
+++ b/python/components/deframers/spino_deframer.py
@@ -41,6 +41,11 @@ class spino_crop(gr.basic_block):
         length = struct.unpack('<H', bytes(msg[16:18]))[0]
         # account for AX.25 headers (14 bytes) and CRC (2 bytes)
         length += 16
+        if length > len(msg):
+            print(f'packet length {length} greater than PDU size {len(msg)};'
+                  ' dropping')
+            return
+
         self.message_port_pub(
             pmt.intern('out'),
             pmt.cons(pmt.car(msg_pmt), pmt.init_u8vector(length, msg)))

--- a/python/sx12xx_packet_crop.py
+++ b/python/sx12xx_packet_crop.py
@@ -40,6 +40,11 @@ class sx12xx_packet_crop(gr.basic_block):
         packet = bytes(pmt.u8vector_elements(msg))
 
         packet_length = packet[0] + 1 + self.crc_len
+        if packet_length > len(packet):
+            print(
+                f'packet length {packet_length} greater than '
+                f'PDU size {len(packet)}; dropping)')
+            return
 
         self.message_port_pub(
             pmt.intern('out'),


### PR DESCRIPTION
When cropping a packet, the call to pmt.init_u8vector(len, data) can result in copying out-of-bounds data if len(data) < len. This adds lengths checks to the cc11x_packet_crop, sx12xx_packet_crop and spino_crop. Additionally, the maximum packet length (used by the sync_to_pdu_packed block) of deframers that use a cc11x_packet_crop or sx12xx_packet_crop block with 2 bytes of CRC has been increased to 258 bytes, so that it's impossible to run into this case.