### PR TITLE
Free structure on error path in Viterbi decoder

### DIFF
--- a/lib/viterbi.c
+++ b/lib/viterbi.c
@@ -127,8 +127,10 @@ void* create_viterbi_packed(int16_t len, const int16_t polys[2])
     set_viterbi_polynomial_packed(polys, vp->branchtab, vp->partab);
 
     vp->dlen = (len + 6) * sizeof(decision_t);
-    if ((vp->decisions = malloc(vp->dlen)) == NULL)
+    if ((vp->decisions = malloc(vp->dlen)) == NULL) {
+        free(vp);
         return NULL;
+    }
 
     init_viterbi_packed(vp, 0);
 


### PR DESCRIPTION
In the Viterbi decoder, if the allocation of the decisions returns an error, free the already allocated Viterbi structure before returning an error.