### PR TITLE
Fix disable logic in TLM submit and default submit_tlm in config

### DIFF
--- a/python/core/gr_satellites_flowgraph.py
+++ b/python/core/gr_satellites_flowgraph.py
@@ -9,6 +9,7 @@
 #
 
 import argparse
+import configparser
 import functools
 import itertools
 import os
@@ -214,7 +215,9 @@ class gr_satellites_flowgraph(gr.hier_block2):
         # submission
         tlm_env = os.environ.get('GR_SATELLITES_SUBMIT_TLM')
         if tlm_env is not None:
-            tlm_submit = bool(int(tlm_env))
+            # BOOLEAN_STATES can convert a few common strings, such as '0',
+            # '1', 'true', 'on', 'false', 'off', to bool.
+            tlm_submit = configparser.ConfigParser.BOOLEAN_STATES[tlm_env]
         else:
             tlm_submit = self.config.getboolean('Groundstation', 'submit_tlm')
         if tlm_submit:

--- a/python/submit.py
+++ b/python/submit.py
@@ -16,7 +16,6 @@ import urllib.request
 
 from gnuradio import gr
 import pmt
-import numpy
 
 
 def parse_timestamp(s):
@@ -78,31 +77,33 @@ class submit(gr.basic_block):
             in_sig=[],
             out_sig=[])
 
-        self.url = url
-        self.request = {
-            'noradID': noradID,
-            'source': source,
-            'locator': 'longLat',
-            'longitude': str(
-                abs(longitude)) + ('E' if longitude >= 0 else 'W'),
-            'latitude': str(
-                abs(latitude)) + ('N' if latitude >= 0 else 'S'),
-            'version': '1.6.6',
+        # Do not do anything if source is not entered or if the location is (0,
+        # 0).
+        self.disabled = not source or (longitude == 0 and latitude == 0)
+
+        if not self.disabled:
+            self.url = url
+            self.request = {
+                'noradID': noradID,
+                'source': source,
+                'locator': 'longLat',
+                'longitude': str(
+                    abs(longitude)) + ('E' if longitude >= 0 else 'W'),
+                'latitude': str(
+                    abs(latitude)) + ('N' if latitude >= 0 else 'S'),
+                'version': '1.6.6',
             }
-        self.initialTimestamp = (
-            parse_timestamp(initialTimestamp)
-            if initialTimestamp != '' else None)
-        self.startTimestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+            self.initialTimestamp = (
+                parse_timestamp(initialTimestamp)
+                if initialTimestamp != '' else None)
+            self.startTimestamp = datetime.datetime.now(
+                tz=datetime.timezone.utc)
 
         self.message_port_register_in(pmt.intern('in'))
         self.set_msg_handler(pmt.intern('in'), self.handle_msg)
 
     def handle_msg(self, msg_pmt):
-        # Check that callsign and QTH have been entered
-        if self.request['source'] == '':
-            return
-        if (self.request['longitude'] == 0.0
-                and self.request['latitude'] == 0.0):
+        if self.disabled:
             return
 
         msg = pmt.cdr(msg_pmt)

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -45,7 +45,7 @@ def write_default_config(file):
         'callsign': '',
         'latitude': 0,
         'longitude': 0,
-        'submit_tlm': 'yes',
+        'submit_tlm': 'no',
     }
 
     config['FUNcube'] = {


### PR DESCRIPTION
This fixes the logic in the telemetry submitter block that is used to avoid sending any telemetry when the callsign or location is not set. The issue with the current approach is that the comparison was done after the latitude and longitude were converted to strings, so the comparison was wrong.

This also fixes the default value for submit_tlm in the config file. The default values should be 'no'.

Additionally, configparser.ConfigParser.BOOLEAN_STATES is used to parse the GR_SATELLITE_SUBMIT_TLM env variable instead of bool(int(.)), since bool(int(.)) has corner cases such as translating '-1' to True.