### PR TITLE
Fix decode_bch15 uint8 overflow in bch15.py

### DIFF
--- a/python/bch15.py
+++ b/python/bch15.py
@@ -112,7 +112,7 @@ Expects an np.array() as bits and modifies it in place
 returns True if decode is successful
 """
     b = np.packbits(bits)
-    p = (b[0] << 7) | (b[1] >> 1)
+    p = (int(b[0]) << 7) | (int(b[1]) >> 1)
     syndromes = [compute_syndrome(p, j) for j in range(d - 1)]
     if not any(syndromes):
         # If all syndromes are zero, there are no errors


### PR DESCRIPTION
`decode_bch15` contains a bug that leads to incorrectly decoding many bch keywords. In line 114 `b` is set to an `NDArray[uint8]` returned by `np.packbits(bits)`, but in line 115 a bitshift happens on its elements: `p = (b[0] << 7) | (b[1] >> 1).` Because `b[0]` is a `uint8` scalar, `b[0] << 7` is evaluated in 8-bit arithmetic and overflows.

In my setup, this created issues with (self-encoded) frames that couldn't be decoded or were wrongly decoded.