### PR TITLE
Add MARINA (69920) and KOSTKA (69935)

### DIFF
--- a/python/satyaml/KOSTKA.yml
+++ b/python/satyaml/KOSTKA.yml
@@ -1,0 +1,14 @@
+name: KOSTKA
+norad: 69935
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  9k6 FSK downlink:
+    frequency: 436.870e+6
+    modulation: FSK
+    baudrate: 9600
+    deviation: 2400
+    framing: AX.25 G3RUH
+    data:
+    - *tlm

--- a/python/satyaml/MARINA.yml
+++ b/python/satyaml/MARINA.yml
@@ -8,7 +8,7 @@ transmitters:
     frequency: 436.680e+6
     modulation: FSK
     baudrate: 9600
-    deviation: 4800
+    deviation: 2400
     framing: AX.25 G3RUH
     data:
     - *tlm

--- a/python/satyaml/MARINA.yml
+++ b/python/satyaml/MARINA.yml
@@ -1,0 +1,14 @@
+name: MARINA
+norad: 69920
+data:
+  &tlm Telemetry:
+    telemetry: ax25
+transmitters:
+  9k6 FSK downlink:
+    frequency: 436.680e+6
+    modulation: FSK
+    baudrate: 9600
+    deviation: 4800
+    framing: AX.25 G3RUH
+    data:
+    - *tlm


### PR DESCRIPTION
[MARINA cubesat](https://db.satnogs.org/satellite/FZQD-0263-2257-6241-5637) - 436.680 MHz - 9k6 FSK, AX.25 G3RUH

[IQ file](https://e.pcloud.link/publink/show?code=XZ4e0y7Z5MfMcP1ylmYhRuicpcotuhmxYc4y)

`gr_satellites MARINA.yml --iq --samp_rate 57600 --rawint16  iq_14637747_MARINA_436680000_57600.raw`

```
-> Packet from 9k6 FSK downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'CQ' (total 2)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'OM9MAR' (total 6)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = True
        control = 0x03
        pid = 0xF0
    info = b'U,1926780,1926802,2,0,2301,2349,2156,57,OM1ATB,99,159373,76,99\x00' (total 63)
```
---
[KOSTKA cubesat](https://db.satnogs.org/satellite/PCVZ-1444-3446-1456-5852) - 436.870 MHz -  9k6 FSK, AX.25 G3RUH

[IQ File](https://e.pcloud.link/publink/show?code=XZvM0y7ZR85wEaKMPOXYinFkvVNA1jzWkJPk)

gr_satellites KOSTKA.yml --iq --rawint16 iq_14671920_OBJECT-BU_436870000_57600.raw --samp_rate 57600`

```
-> Packet from 9k6 FSK downlink
Container: 
    header = Container: 
        addresses = ListContainer: 
            Container: 
                callsign = u'CQ' (total 2)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = False
            Container: 
                callsign = u'OK0KST' (total 6)
                ssid = Container: 
                    ch = False
                    ssid = 0
                    extension = True
        control = 0x03
        pid = 0xF0
    info = b'255,0,16,1881538,2338241,1785728794,0,11.00,-1.95' (total 49)
```
