### PR TITLE
Pass real point-in-file through during replay from wav file for accurate timestamps

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -747,15 +747,25 @@ Getting correct timestamps with recordings
 One of the difficulties with working with recordings is obtaining correct
 timestamps for each of the decoded packets. These timestamps are included in
 KISS files and telemetry submissions to some servers, such as SatNOGS DB. To
-produced correct timestamps ``gr_satellites`` will play back the recording at 1x
-speed and count the clock time elapsed since the beginning of the execution, it
-will then add that time to a timestamp specified by the user, which should
-correspond to the start of the recording.
+produce correct timestamps, always use the ``--start_time`` parameter followed
+by the timestamp in ISO 8601 format (``YYYY-MM-DDTHH:MM:SS``) to indicate the
+start time of the recording.
 
-To use this functionality it is necessary to use the ``--throttle`` parameter to
-limit playback speed to 1x and use the ``--start_time`` parameter followed by the
-timestamp in ISO 8601 format (``YYYY-MM-DDTHH:MM:SS``) to indicate the start time
-of the recording.
+Many deframers (those based on ``sync_to_pdu``, such as most fixed-length
+framings, and the AX.25 deframer) attach the offset of each frame within the
+recording to the decoded packet. When this information is available,
+``gr_satellites`` computes each packet's timestamp directly from that offset
+and the transmitter's baudrate, so the recording can be decoded as fast as
+possible while still producing correct timestamps; ``--throttle`` is not
+needed in this case.
+
+For deframers that do not yet attach this information, ``gr_satellites``
+falls back to playing back the recording at 1x speed and counting the clock
+time elapsed since the beginning of the execution, adding that elapsed time
+to the timestamp given by ``--start_time``. To use this fallback it is
+necessary to use the ``--throttle`` parameter to limit playback speed to 1x
+(this is harmless to leave enabled even when the faster, offset-based
+timestamping applies).
 
 Treating unknown args as warning
 """"""""""""""""""""""""""""""""

--- a/lib/ax100_decode_impl.cc
+++ b/lib/ax100_decode_impl.cc
@@ -90,7 +90,7 @@ void ax100_decode_impl::msg_handler(pmt::pmt_t pmt_msg)
         // Send by GNUradio message
         message_port_pub(
             pmt::mp("out"),
-            pmt::cons(pmt::PMT_NIL, pmt::init_u8vector(frame_len, &d_data[1])));
+            pmt::cons(pmt::car(pmt_msg), pmt::init_u8vector(frame_len, &d_data[1])));
     } else if (d_verbose) {
         std::printf("RS decode failed.\n");
     }

--- a/lib/decode_ra_code_impl.cc
+++ b/lib/decode_ra_code_impl.cc
@@ -107,7 +107,7 @@ void decode_ra_code_impl::msg_handler(pmt::pmt_t pmt_msg)
     if ((float)errors / (ra_code_length * RA_BITCOUNT) < d_error_threshold) {
         message_port_pub(
             pmt::mp("out"),
-            pmt::cons(pmt::PMT_NIL, pmt::init_u8vector(d_size, d_ra_out.data())));
+            pmt::cons(pmt::car(pmt_msg), pmt::init_u8vector(d_size, d_ra_out.data())));
     }
 }
 

--- a/lib/distributed_syncframe_soft_impl.cc
+++ b/lib/distributed_syncframe_soft_impl.cc
@@ -66,13 +66,11 @@ int distributed_syncframe_soft_impl::work(int noutput_items,
         if (match >= d_syncword.size() - d_threshold) {
             // sync found
             pmt::pmt_t meta = pmt::make_dict();
-            meta = pmt::dict_add(meta,
-                                 pmt::mp("sample_offset"),
-                                 pmt::from_uint64(nitems_read(0) + i));
+            meta = pmt::dict_add(
+                meta, pmt::mp("sample_offset"), pmt::from_uint64(nitems_read(0) + i));
             message_port_pub(
                 pmt::mp("out"),
-                pmt::cons(meta,
-                          pmt::init_f32vector(d_syncword.size() * d_step, in + i)));
+                pmt::cons(meta, pmt::init_f32vector(d_syncword.size() * d_step, in + i)));
         }
     }
 

--- a/lib/distributed_syncframe_soft_impl.cc
+++ b/lib/distributed_syncframe_soft_impl.cc
@@ -65,9 +65,13 @@ int distributed_syncframe_soft_impl::work(int noutput_items,
         }
         if (match >= d_syncword.size() - d_threshold) {
             // sync found
+            pmt::pmt_t meta = pmt::make_dict();
+            meta = pmt::dict_add(meta,
+                                 pmt::mp("sample_offset"),
+                                 pmt::from_uint64(nitems_read(0) + i));
             message_port_pub(
                 pmt::mp("out"),
-                pmt::cons(pmt::PMT_NIL,
+                pmt::cons(meta,
                           pmt::init_f32vector(d_syncword.size() * d_step, in + i)));
         }
     }

--- a/lib/fixedlen_to_pdu_impl.cc
+++ b/lib/fixedlen_to_pdu_impl.cc
@@ -141,9 +141,12 @@ int fixedlen_to_pdu_impl::work(int noutput_items,
                 }
                 pack_packet(pdu_items);
             }
+            pmt::pmt_t meta = pmt::make_dict();
+            meta = pmt::dict_add(
+                meta, pmt::mp("sample_offset"), pmt::from_uint64(info.offset));
             message_port_pub(
                 msgport_names::pdus(),
-                pmt::cons(pmt::PMT_NIL,
+                pmt::cons(meta,
                           pdu::make_pdu_vector(d_type, d_packet.data(), pdu_items)));
         } else {
             // End of packet not yet available. Save for next run

--- a/lib/lilacsat1_demux_impl.cc
+++ b/lib/lilacsat1_demux_impl.cc
@@ -74,13 +74,11 @@ int lilacsat1_demux_impl::work(int noutput_items,
             d_position = -1;
 
             pmt::pmt_t meta = pmt::make_dict();
-            meta = pmt::dict_add(meta,
-                                 pmt::mp("sample_offset"),
-                                 pmt::from_uint64(nitems_read(0) + i));
+            meta = pmt::dict_add(
+                meta, pmt::mp("sample_offset"), pmt::from_uint64(nitems_read(0) + i));
             message_port_pub(
                 pmt::mp("frame"),
-                pmt::cons(meta,
-                          pmt::init_u8vector(d_frame.size(), d_frame.data())));
+                pmt::cons(meta, pmt::init_u8vector(d_frame.size(), d_frame.data())));
             d_frame.fill(0);
         }
 

--- a/lib/lilacsat1_demux_impl.cc
+++ b/lib/lilacsat1_demux_impl.cc
@@ -73,9 +73,13 @@ int lilacsat1_demux_impl::work(int noutput_items,
         if (d_position == d_packet_len * d_bits_per_byte) {
             d_position = -1;
 
+            pmt::pmt_t meta = pmt::make_dict();
+            meta = pmt::dict_add(meta,
+                                 pmt::mp("sample_offset"),
+                                 pmt::from_uint64(nitems_read(0) + i));
             message_port_pub(
                 pmt::mp("frame"),
-                pmt::cons(pmt::PMT_NIL,
+                pmt::cons(meta,
                           pmt::init_u8vector(d_frame.size(), d_frame.data())));
             d_frame.fill(0);
         }

--- a/lib/matrix_deinterleaver_soft_impl.cc
+++ b/lib/matrix_deinterleaver_soft_impl.cc
@@ -88,7 +88,7 @@ void matrix_deinterleaver_soft_impl::msg_handler(pmt::pmt_t pmt_msg)
     // Output cropping
     message_port_pub(
         pmt::mp("out"),
-        pmt::cons(pmt::PMT_NIL,
+        pmt::cons(pmt::car(pmt_msg),
                   pmt::init_f32vector(d_output_size, &d_out[d_output_skip])));
 }
 

--- a/lib/nusat_decoder_impl.cc
+++ b/lib/nusat_decoder_impl.cc
@@ -144,7 +144,7 @@ void nusat_decoder_impl::msg_handler(pmt::pmt_t pmt_msg)
 
     // Send by GNUradio message
     message_port_pub(pmt::mp("out"),
-                     pmt::cons(pmt::PMT_NIL, pmt::init_u8vector(length, packet)));
+                     pmt::cons(pmt::car(pmt_msg), pmt::init_u8vector(length, packet)));
 }
 } /* namespace satellites */
 } /* namespace gr */

--- a/lib/u482c_decode_impl.cc
+++ b/lib/u482c_decode_impl.cc
@@ -170,7 +170,7 @@ void u482c_decode_impl::msg_handler(pmt::pmt_t pmt_msg)
 
     // Send via GNU Radio message
     message_port_pub(pmt::mp("out"),
-                     pmt::cons(pmt::PMT_NIL, pmt::init_u8vector(rx_len, packet)));
+                     pmt::cons(pmt::car(pmt_msg), pmt::init_u8vector(rx_len, packet)));
 }
 } /* namespace satellites */
 } /* namespace gr */

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -71,6 +71,7 @@ GR_PYTHON_INSTALL(
     lilacsat1_gps_kml.py
     ngham_packet_crop.py
     ngham_remove_padding.py
+    pdu_add_timestamp.py
     pdu_to_kiss.py
     print_header.py
     print_timestamp.py

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -74,6 +74,7 @@ from .ks1q_header_remover import ks1q_header_remover
 from .lilacsat1_gps_kml import lilacsat1_gps_kml
 from .ngham_packet_crop import ngham_packet_crop
 from .ngham_remove_padding import ngham_remove_padding
+from .pdu_add_timestamp import pdu_add_timestamp
 from .pdu_to_kiss import pdu_to_kiss
 from .print_header import print_header
 from .print_timestamp import print_timestamp

--- a/python/aausat4_remove_fsm.py
+++ b/python/aausat4_remove_fsm.py
@@ -38,9 +38,9 @@ class aausat4_remove_fsm(gr.basic_block):
         packet_long = pmt.f32vector_elements(msg)[8:8+1996]
         self.message_port_pub(
             pmt.intern('short'),
-            pmt.cons(pmt.PMT_NIL,
+            pmt.cons(pmt.car(msg_pmt),
                      pmt.init_f32vector(len(packet_short), packet_short)))
         self.message_port_pub(
             pmt.intern('long'),
-            pmt.cons(pmt.PMT_NIL,
+            pmt.cons(pmt.car(msg_pmt),
                      pmt.init_f32vector(len(packet_long), packet_long)))

--- a/python/components/transports/nanolink_transport.py
+++ b/python/components/transports/nanolink_transport.py
@@ -83,7 +83,7 @@ class nanolink_defragmenter(gr.basic_block):
                 self.remain = None
                 self.message_port_pub(
                     pmt.intern('out'),
-                    pmt.cons(pmt.PMT_NIL,
+                    pmt.cons(meta,
                              pmt.init_u8vector(len(self.current),
                                                list(self.current))))
 

--- a/python/components/transports/tm_kiss_transport.py
+++ b/python/components/transports/tm_kiss_transport.py
@@ -43,6 +43,7 @@ class tm_kiss_transport(gr.basic_block):
             TMPrimaryHeaderShort if short_tm else TMPrimaryHeader)
 
     def handle_msg(self, msg_pmt):
+        meta = pmt.car(msg_pmt)
         msg = pmt.cdr(msg_pmt)
         if not pmt.is_u8vector(msg):
             print('[ERROR] Received invalid message type. Expected u8vector')
@@ -62,7 +63,7 @@ class tm_kiss_transport(gr.basic_block):
                 if len(packet) > 0:
                     self.message_port_pub(
                         pmt.intern('out'),
-                        pmt.cons(pmt.PMT_NIL,
+                        pmt.cons(meta,
                                  pmt.init_u8vector(len(packet), packet)))
                     self.packets[vc] = []
             elif self.transpose[vc]:

--- a/python/core/gr_satellites_flowgraph.py
+++ b/python/core/gr_satellites_flowgraph.py
@@ -26,6 +26,7 @@ from ..components import demodulators
 from ..components import transports
 from ..satyaml import yamlfiles
 from .. import pdu_add_meta
+from .. import pdu_add_timestamp
 
 
 def set_options(cl, *args, **kwargs):
@@ -159,6 +160,7 @@ class gr_satellites_flowgraph(gr.hier_block2):
             self._demodulators = dict()
             self._deframers = dict()
             self._taggers = dict()
+            self._timestampers = dict()
             for key, transmitter in satyaml['transmitters'].items():
                 self._init_demodulator_deframer(key, transmitter)
 
@@ -304,6 +306,19 @@ class gr_satellites_flowgraph(gr.hier_block2):
         tagger = pdu_add_meta(meta)
         self._taggers[key] = tagger
         self.msg_connect((deframer, 'out'), (tagger, 'in'))
+
+        # Turn the 'sample_offset' metadata some deframers attach to their
+        # PDUs (the offset, in symbols, of the frame within the deframer's
+        # input stream) into an absolute 'timestamp' metadata entry, using
+        # the transmitter's baudrate and the recording start time. This
+        # allows datasinks to compute correct per-packet timestamps without
+        # needing the flowgraph to be throttled to 1x playback speed.
+        start_time = getattr(self.options, 'start_time', '') \
+            if self.options is not None else ''
+        timestamper = pdu_add_timestamp(transmitter['baudrate'], start_time)
+        self._timestampers[key] = timestamper
+        self.msg_connect((tagger, 'out'), (timestamper, 'in'))
+        tagger = timestamper
 
         if self.grc_block:
             # If we are a GRC block we have no datasinks

--- a/python/hdlc_deframer.py
+++ b/python/hdlc_deframer.py
@@ -61,8 +61,9 @@ class hdlc_deframer(gr.sync_block):
 
     def work(self, input_items, output_items):
         in0 = input_items[0]
+        nitems = self.nitems_read(0)
 
-        for x in in0:
+        for i, x in enumerate(in0):
             if x:
                 self.ones += 1
                 self.bits.append(x)
@@ -84,9 +85,15 @@ class hdlc_deframer(gr.sync_block):
                     if frame and (not self.check or self.fcs_ok(frame)):
                         # Send frame
                         buff = frame[:-2]  # trim fcs
+                        # sample_offset is the offset of the closing flag,
+                        # used to derive a per-packet timestamp when
+                        # replaying a recording (see pdu_add_timestamp)
+                        meta = pmt.dict_add(
+                            pmt.make_dict(), pmt.intern('sample_offset'),
+                            pmt.from_uint64(nitems + i))
                         self.message_port_pub(
                             pmt.intern('out'),
-                            pmt.cons(pmt.PMT_NIL,
+                            pmt.cons(meta,
                                      pmt.init_u8vector(len(buff), buff)))
                 else:
                     self.bits.append(x)

--- a/python/k2sat_deframer.py
+++ b/python/k2sat_deframer.py
@@ -79,7 +79,7 @@ class k2sat_deframer(gr.basic_block):
                 ax25_packet = list(packet)  # conversion to list for pybind11
                 self.message_port_pub(
                     pmt.intern('out'),
-                    pmt.cons(pmt.PMT_NIL,
+                    pmt.cons(pmt.car(msg_pmt),
                              pmt.init_u8vector(len(ax25_packet), ax25_packet)))
             start = idx + 2
 

--- a/python/kiss_to_pdu.py
+++ b/python/kiss_to_pdu.py
@@ -47,7 +47,8 @@ class kiss_to_pdu(gr.sync_block):
         tag_idx = 0
 
         for i, c in enumerate(input_items[0]):
-            while tag_idx < len(tags) and tags[tag_idx].offset <= nitems_start + i:
+            while (tag_idx < len(tags)
+                   and tags[tag_idx].offset <= nitems_start + i):
                 self.meta = pmt.dict_add(
                     self.meta, tags[tag_idx].key, tags[tag_idx].value)
                 tag_idx += 1

--- a/python/kiss_to_pdu.py
+++ b/python/kiss_to_pdu.py
@@ -29,18 +29,35 @@ class kiss_to_pdu(gr.sync_block):
         self.pdu = list()
         self.transpose = False
         self.control_byte = control_byte
+        # Metadata (e.g. 'timestamp') carried by pdu_to_tagged_stream as
+        # stream tags on the PDU this byte stream was built from. Updated
+        # as tags are encountered, so it reflects the most recent PDU seen
+        # so far; used as a best-effort metadata source for the PDUs
+        # reconstructed here, since a single upstream PDU may contain
+        # several KISS-encapsulated frames (or a frame may span more than
+        # one upstream PDU).
+        self.meta = pmt.make_dict()
 
         self.message_port_register_out(pmt.intern('out'))
 
     def work(self, input_items, output_items):
-        for c in input_items[0]:
+        nitems_start = self.nitems_read(0)
+        n = len(input_items[0])
+        tags = sorted(self.get_tags_in_window(0, 0, n), key=lambda t: t.offset)
+        tag_idx = 0
+
+        for i, c in enumerate(input_items[0]):
+            while tag_idx < len(tags) and tags[tag_idx].offset <= nitems_start + i:
+                self.meta = pmt.dict_add(
+                    self.meta, tags[tag_idx].key, tags[tag_idx].value)
+                tag_idx += 1
             if c == FEND:
                 if (self.pdu
                         and (not self.control_byte or not self.pdu[0] & 0x0f)):
                     msg = self.pdu[1:] if self.control_byte else self.pdu
                     self.message_port_pub(
                         pmt.intern('out'),
-                        pmt.cons(pmt.PMT_NIL,
+                        pmt.cons(self.meta,
                                  pmt.init_u8vector(len(msg), msg)))
                 self.pdu = list()
             elif self.transpose:

--- a/python/pdu_add_timestamp.py
+++ b/python/pdu_add_timestamp.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Daniel Estevez <daniel@destevez.net>
+#
+# This file is part of gr-satellites
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import datetime
+
+from gnuradio import gr
+import pmt
+
+from .submit import parse_timestamp
+
+
+class pdu_add_timestamp(gr.basic_block):
+    """
+    Adds a 'timestamp' metadata entry to PDUs
+
+    The timestamp is computed from the PDU 'sample_offset' metadata entry
+    (if present), which some deframers set to the offset, in symbols, of
+    the frame within the stream fed to the deframer. This is combined with
+    the symbol rate and a start time (corresponding to the first symbol
+    of the recording) to compute an absolute timestamp for the packet.
+
+    This allows getting correct per-packet timestamps when replaying a
+    recording as fast as possible (i.e., without using --throttle to play
+    it back at 1x speed), as long as the deframer that produced the PDU
+    attaches 'sample_offset' metadata to it.
+
+    If the PDU has no 'sample_offset' metadata, or no start time is given,
+    the PDU is passed through unmodified, so that downstream blocks fall
+    back to their wall-clock based timestamping.
+
+    Args:
+        baudrate: symbol rate of the deframer that produced the PDU (float)
+        start_time: timestamp corresponding to the first symbol
+            of the recording (string, ISO 8601 format)
+    """
+    def __init__(self, baudrate, start_time=''):
+        gr.basic_block.__init__(
+            self,
+            name='pdu_add_timestamp',
+            in_sig=None,
+            out_sig=None)
+        self.baudrate = baudrate
+        self.start_time = parse_timestamp(start_time) if start_time else None
+
+        self.message_port_register_in(pmt.intern('in'))
+        self.set_msg_handler(pmt.intern('in'), self.handle_msg)
+        self.message_port_register_out(pmt.intern('out'))
+
+    def handle_msg(self, msg_pmt):
+        if self.start_time is None:
+            self.message_port_pub(pmt.intern('out'), msg_pmt)
+            return
+
+        meta = pmt.car(msg_pmt)
+        data = pmt.cdr(msg_pmt)
+
+        offset_key = pmt.intern('sample_offset')
+        if pmt.is_dict(meta) and pmt.dict_has_key(meta, offset_key):
+            offset = pmt.to_uint64(pmt.dict_ref(meta, offset_key, pmt.PMT_NIL))
+            timestamp = self.start_time + datetime.timedelta(
+                seconds=offset / self.baudrate)
+            meta = pmt.dict_add(
+                meta, pmt.intern('timestamp'),
+                pmt.from_double(timestamp.timestamp()))
+
+        self.message_port_pub(pmt.intern('out'), pmt.cons(meta, data))

--- a/python/pdu_to_kiss.py
+++ b/python/pdu_to_kiss.py
@@ -45,16 +45,29 @@ class pdu_to_kiss(gr.basic_block):
         self.set_msg_handler(pmt.intern('in'), self.handle_msg)
         self.message_port_register_out(pmt.intern('out'))
 
-    def create_timestamp(self):
+    def create_timestamp(self, msg_pmt):
         """Returns the timestamp as a KISS control frame with control byte 09
 
         The timestamp is the number of milliseconds elapsed since the UNIX
         epoch according to UTC and not counting leap seconds, stored as a
         big-endian 64 bit unsigned integer
+
+        If the PDU carries a 'timestamp' metadata entry (added by
+        pdu_add_timestamp from a per-packet sample offset), that timestamp
+        is used. Otherwise, the timestamp is computed from the wall-clock
+        time elapsed since this block started, which requires the flowgraph
+        to be run at 1x speed (e.g. using --throttle) to be correct.
         """
-        t_now = datetime.datetime.now(tz=datetime.timezone.utc)
-        if self.initial_timestamp:
-            t_now = t_now - self.start_timestamp + self.initial_timestamp
+        meta = pmt.car(msg_pmt)
+        timestamp_key = pmt.intern('timestamp')
+        if pmt.is_dict(meta) and pmt.dict_has_key(meta, timestamp_key):
+            t_now = datetime.datetime.fromtimestamp(
+                pmt.to_double(pmt.dict_ref(meta, timestamp_key, pmt.PMT_NIL)),
+                tz=datetime.timezone.utc)
+        else:
+            t_now = datetime.datetime.now(tz=datetime.timezone.utc)
+            if self.initial_timestamp:
+                t_now = t_now - self.start_timestamp + self.initial_timestamp
         t_now_kiss = round(t_now.timestamp() * 1e3)
         control = b'\x09'
         return control + struct.pack('>Q', t_now_kiss)
@@ -71,7 +84,7 @@ class pdu_to_kiss(gr.basic_block):
 
         if self.include_timestamp:
             timestamp_frame = ([FEND]
-                               + kiss_escape(self.create_timestamp())
+                               + kiss_escape(self.create_timestamp(msg_pmt))
                                + [FEND])
             self.message_port_pub(
                 pmt.intern('out'),

--- a/python/reflect_bytes.py
+++ b/python/reflect_bytes.py
@@ -39,4 +39,4 @@ class reflect_bytes(gr.basic_block):
 
         self.message_port_pub(
             pmt.intern('out'),
-            pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(len(packet), packet)))
+            pmt.cons(pmt.car(msg_pmt), pmt.init_u8vector(len(packet), packet)))

--- a/python/snet_deframer.py
+++ b/python/snet_deframer.py
@@ -165,7 +165,9 @@ class snet_deframer(gr.basic_block):
             return
 
         pdu = np.packbits(pdu_bytes)
-        pdu_tags = pmt.make_dict()
+        pdu_tags = pmt.car(msg_pmt)
+        if not pmt.is_dict(pdu_tags):
+            pdu_tags = pmt.make_dict()
         pdu_tags = pmt.dict_add(
             pdu_tags, pmt.intern('SNET SrcId'), pmt.from_long(hdr.SrcId))
         self.message_port_pub(

--- a/python/submit.py
+++ b/python/submit.py
@@ -113,10 +113,17 @@ class submit(gr.basic_block):
 
         self.request['frame'] = bytes(pmt.u8vector_elements(msg)).hex().upper()
 
-        t_now = datetime.datetime.now(tz=datetime.timezone.utc)
-        t_prop = (
-            t_now - self.startTimestamp + self.initialTimestamp
-            if self.initialTimestamp else t_now)
+        meta = pmt.car(msg_pmt)
+        timestamp_key = pmt.intern('timestamp')
+        if pmt.is_dict(meta) and pmt.dict_has_key(meta, timestamp_key):
+            t_prop = datetime.datetime.fromtimestamp(
+                pmt.to_double(pmt.dict_ref(meta, timestamp_key, pmt.PMT_NIL)),
+                tz=datetime.timezone.utc)
+        else:
+            t_now = datetime.datetime.now(tz=datetime.timezone.utc)
+            t_prop = (
+                t_now - self.startTimestamp + self.initialTimestamp
+                if self.initialTimestamp else t_now)
         t_prop_fmt = t_prop.replace(tzinfo=None).isoformat()[:-3] + 'Z'
         self.request['timestamp'] = t_prop_fmt
 


### PR DESCRIPTION
Fixes #92 (the oldest currently-open issue). 

This has been tested a fair bit, though focusing on decoding from wav files. I haven't tested it with live decoding or anything, though I don't suspect there'll be any regressions for those.

The only possible "regression" is in the case of using `--start_time` with a live/hardware source. Previously, that configuration spits out realtime timestamps. Now, it'll produce timestamps based on the sample rate and sample count, which may have different behaviour than previously. I suspect there aren't a lot of people using `--start_time` with a live/hardware source, so it's probably not a huge deal in reality. It is my opinion that this is better, and shouldn't be considered a regression. 