### PR TITLE
chore(ci): Upgrade checkout action to v7

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -12,5 +12,5 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: daniestevez/gr-satellites-ci-action@v2.1.0

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Run clang-format
       run: |
         find . -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.cc' -o -name '*.c' | \

--- a/.github/workflows/pycodestyle.yml
+++ b/.github/workflows/pycodestyle.yml
@@ -9,7 +9,7 @@ jobs:
   pycodestyle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install pycodestyle
         run: pip install pycodestyle
       - name: Run pycodestyle


### PR DESCRIPTION
Upgrade to the latest version to get rid of the warning about out-of-date Node versions