### PR TITLE
Add FrontierSat satyaml file

### DIFF
--- a/python/satyaml/FrontierSat.yml
+++ b/python/satyaml/FrontierSat.yml
@@ -2,7 +2,7 @@ name: FRONTIERSAT
 norad: 69015
 data:
   &tlm Telemetry:
-    telemetry: hexdump
+    unknown
 transmitters:
   9k6 FSK downlink:
     frequency: 436.150e+6

--- a/python/satyaml/FrontierSat.yml
+++ b/python/satyaml/FrontierSat.yml
@@ -1,0 +1,17 @@
+name: FRONTIERSAT
+norad: 69015
+data:
+  &tlm Telemetry:
+    telemetry: hexdump
+transmitters:
+  9k6 FSK downlink:
+    frequency: 436.150e+6
+    modulation: FSK
+    baudrate: 9600
+    deviation: 3200
+    framing: AX100 ASM+Golay
+    scrambler: CCSDS
+    syncword: 4
+    data:
+    - *tlm
+

--- a/python/satyaml/FrontierSat.yml
+++ b/python/satyaml/FrontierSat.yml
@@ -10,8 +10,8 @@ transmitters:
     baudrate: 9600
     deviation: 3200
     framing: AX100 ASM+Golay
-    scrambler: CCSDS
-    syncword: 4
     data:
     - *tlm
+
+# AX100 Configuration: https://github.com/CalgaryToSpace/CTS-SAT-1-Ground-Station/blob/main/docs/AX100_Config_Dump.txt
 


### PR DESCRIPTION
To validate, you can download the audio from https://network.satnogs.org/observations/14813295/ (or any observation). For example:

```bash
wget 'https://network-satnogs.freetls.fastly.net/media/data_obs/2026/8/18/17/14813295/satnogs_14813295_2026-08-18T17-05-35.ogg'
sox satnogs_14813295_2026-08-18T17-05-35.ogg satnogs_14813295_2026-08-18T17-05-35.wav
gr_satellites python/satyaml/FrontierSat.yml --hexdump --wavfile satnogs_14813295_2026-08-18T17-05-35.wav
```